### PR TITLE
Added try_send and try_receive methods

### DIFF
--- a/src/channel/error.rs
+++ b/src/channel/error.rs
@@ -6,3 +6,67 @@
 /// The error recovers the value that has been sent.
 #[derive(PartialEq, Debug)]
 pub struct ChannelSendError<T>(pub T);
+
+/// The error which is returned when trying to receive from a channel
+/// without blocking fails.
+#[derive(PartialEq, Debug, Copy, Clone)]
+pub enum TryReceiveError {
+    /// The channel is empty.
+    Empty,
+    /// The channel was closed and is empty.
+    Closed,
+}
+
+impl TryReceiveError {
+    /// Returns whether the error is the `WouldBlock` variant.
+    pub fn is_empty(self) -> bool {
+        match self {
+            Self::Empty => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the error is the `Closed` variant.
+    pub fn is_closed(self) -> bool {
+        match self {
+            Self::Closed => true,
+            _ => false,
+        }
+    }
+}
+
+/// The error which is returned when trying to send on a channel
+/// without blocking fails.
+#[derive(PartialEq, Debug)]
+pub enum TrySendError<T> {
+    /// The channel is full.
+    Full(T),
+    /// The channel was closed.
+    Closed(T),
+}
+
+impl<T> TrySendError<T> {
+    /// Converts the error into its inner value.
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Closed(inner) => inner,
+            Self::Full(inner) => inner,
+        }
+    }
+
+    /// Returns whether the error is the `WouldBlock` variant.
+    pub fn is_full(&self) -> bool {
+        match self {
+            Self::Full(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the error is the `Closed` variant.
+    pub fn is_closed(&self) -> bool {
+        match self {
+            Self::Closed(_) => true,
+            _ => false,
+        }
+    }
+}

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -4,7 +4,7 @@
 //! asynchronous tasks.
 
 mod error;
-pub use self::error::ChannelSendError;
+pub use self::error::{ChannelSendError, TryReceiveError, TrySendError};
 
 mod channel_future;
 use channel_future::{

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -12,7 +12,7 @@ use lock_api::{Mutex, RawMutex};
 use super::{
     ChannelReceiveAccess, ChannelReceiveFuture, ChannelSendAccess,
     ChannelSendFuture, RecvPollState, RecvWaitQueueEntry, SendPollState,
-    SendWaitQueueEntry,
+    SendWaitQueueEntry, TryReceiveError, TrySendError,
 };
 
 fn wake_recv_waiters(mut waiters: LinkedList<RecvWaitQueueEntry>) {
@@ -107,13 +107,34 @@ where
         wake_send_waiters(send_waiters);
     }
 
+    /// Attempt to send a value without blocking.
+    fn try_send(&mut self, value: T) -> Result<(), TrySendError<T>> {
+        debug_assert!(
+            self.buffer.capacity() > 0,
+            "try_send is not supported for unbuffered channels"
+        );
+
+        if self.is_closed {
+            Err(TrySendError::Closed(value))
+        } else if self.buffer.can_push() {
+            self.buffer.push(value);
+
+            // Wakeup the oldest receive waiter
+            wakeup_last_receive_waiter(&mut self.receive_waiters);
+
+            Ok(())
+        } else {
+            Err(TrySendError::Full(value))
+        }
+    }
+
     /// Tries to send a value to the channel.
     /// If the value isn't available yet, the ChannelSendFuture gets added to the
     /// wait queue at the channel, and will be signalled once ready.
     /// If the channels is already closed, the value to send is returned.
     /// This function is only safe as long as the `wait_node`s address is guaranteed
     /// to be stable until it gets removed from the queue.
-    unsafe fn try_send(
+    unsafe fn send_or_register(
         &mut self,
         wait_node: &mut ListNode<SendWaitQueueEntry<T>>,
         cx: &mut Context<'_>,
@@ -182,12 +203,55 @@ where
         }
     }
 
+    /// This path should be only used for 0 capacity queues.
+    /// Since the list is not empty, a value is available.
+    /// Extract it from the sender in order to return it
+    fn take_from_sender(&mut self) -> T {
+        debug_assert_eq!(0, self.buffer.capacity());
+        let last_sender = self.send_waiters.remove_last();
+        debug_assert!(!last_sender.is_null());
+
+        // Safety: The sender can't be null, since we only add valid
+        // senders to the queue
+        let last_sender = unsafe { &mut (*last_sender) };
+        let val = last_sender.value.take().expect("Value must be available");
+        last_sender.state = SendPollState::SendComplete;
+
+        // Wakeup the waiter
+        if let Some(ref task) = &last_sender.task {
+            task.wake_by_ref();
+        }
+
+        val
+    }
+
+    /// Tries to receive a value from the channel without blocking.
+    fn try_receive(&mut self) -> Result<T, TryReceiveError> {
+        if !self.buffer.is_empty() {
+            let val = self.buffer.pop();
+
+            // Since this means a space in the buffer had been freed,
+            // try to copy a value from a potential waiter into the channel.
+            unsafe { self.try_copy_value_from_last_waiter() };
+
+            Ok(val)
+        } else if !self.send_waiters.is_empty() {
+            let val = self.take_from_sender();
+
+            Ok(val)
+        } else if self.is_closed {
+            Err(TryReceiveError::Closed)
+        } else {
+            Err(TryReceiveError::Empty)
+        }
+    }
+
     /// Tries to read the value from the channel.
     /// If the value isn't available yet, the ChannelReceiveFuture gets added to the
     /// wait queue at the channel, and will be signalled once ready.
     /// This function is only safe as long as the `wait_node`s address is guaranteed
     /// to be stable until it gets removed from the queue.
-    unsafe fn try_receive(
+    unsafe fn receive_or_register(
         &mut self,
         wait_node: &mut ListNode<RecvWaitQueueEntry>,
         cx: &mut Context<'_>,
@@ -196,45 +260,16 @@ where
             RecvPollState::Unregistered | RecvPollState::Notified => {
                 wait_node.state = RecvPollState::Unregistered;
 
-                if !self.buffer.is_empty() {
-                    // A value is available - grab it.
-                    let val = self.buffer.pop();
-
-                    // Since this means a space in the buffer had been freed,
-                    // try to copy a value from a potential waiter into the channel.
-                    self.try_copy_value_from_last_waiter();
-                    Poll::Ready(Some(val))
-                } else if !self.send_waiters.is_empty() {
-                    // This path should be only used for 0 capacity queues.
-                    // Since the list is not empty, a value is available.
-                    // Extract it from the sender in order to return it
-                    assert_eq!(0, self.buffer.capacity());
-                    let last_sender = self.send_waiters.remove_last();
-                    assert!(!last_sender.is_null());
-
-                    // Safety: The sender can't be null, since we only add valid
-                    // senders to the queue
-                    let last_sender = &mut (*last_sender);
-                    let val = last_sender
-                        .value
-                        .take()
-                        .expect("Value must be available");
-                    last_sender.state = SendPollState::SendComplete;
-
-                    // Wakeup the waiter
-                    if let Some(ref task) = &last_sender.task {
-                        task.wake_by_ref();
+                match self.try_receive() {
+                    Ok(val) => Poll::Ready(Some(val)),
+                    Err(TryReceiveError::Closed) => Poll::Ready(None),
+                    Err(TryReceiveError::Empty) => {
+                        // Added the task to the wait queue
+                        wait_node.task = Some(cx.waker().clone());
+                        wait_node.state = RecvPollState::Registered;
+                        self.receive_waiters.add_front(wait_node);
+                        Poll::Pending
                     }
-
-                    Poll::Ready(Some(val))
-                } else if self.is_closed {
-                    Poll::Ready(None)
-                } else {
-                    // Added the task to the wait queue
-                    wait_node.task = Some(cx.waker().clone());
-                    wait_node.state = RecvPollState::Registered;
-                    self.receive_waiters.add_front(wait_node);
-                    Poll::Pending
                 }
             }
             RecvPollState::Registered => {
@@ -376,6 +411,14 @@ where
         }
     }
 
+    /// Attempt to send the value without blocking.
+    ///
+    /// This operation is not supported for unbuffered channels and will
+    /// panic if the capacity of the `RingBuf` is zero.
+    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+        self.inner.lock().try_send(value)
+    }
+
     /// Returns a future that gets fulfilled when a value is written to the channel.
     /// If the channels gets closed, the future will resolve to `None`.
     pub fn receive(&self) -> ChannelReceiveFuture<MutexType, T> {
@@ -384,6 +427,11 @@ where
             wait_node: ListNode::new(RecvWaitQueueEntry::new()),
             _phantom: PhantomData,
         }
+    }
+
+    /// Attempt to receive a value of the channel without blocking.
+    pub fn try_receive(&self) -> Result<T, TryReceiveError> {
+        self.inner.lock().try_receive()
     }
 
     /// Closes the channel.
@@ -400,12 +448,12 @@ impl<MutexType: RawMutex, T, A> ChannelSendAccess<T>
 where
     A: RingBuf<Item = T>,
 {
-    unsafe fn try_send(
+    unsafe fn send_or_register(
         &self,
         wait_node: &mut ListNode<SendWaitQueueEntry<T>>,
         cx: &mut Context<'_>,
     ) -> (Poll<()>, Option<T>) {
-        self.inner.lock().try_send(wait_node, cx)
+        self.inner.lock().send_or_register(wait_node, cx)
     }
 
     fn remove_send_waiter(
@@ -421,12 +469,12 @@ impl<MutexType: RawMutex, T, A> ChannelReceiveAccess<T>
 where
     A: RingBuf<Item = T>,
 {
-    unsafe fn try_receive(
+    unsafe fn receive_or_register(
         &self,
         wait_node: &mut ListNode<RecvWaitQueueEntry>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<T>> {
-        self.inner.lock().try_receive(wait_node, cx)
+        self.inner.lock().receive_or_register(wait_node, cx)
     }
 
     fn remove_receive_waiter(
@@ -508,12 +556,12 @@ mod if_alloc {
         where
             MutexType: RawMutex,
         {
-            unsafe fn try_receive(
+            unsafe fn receive_or_register(
                 &self,
                 wait_node: &mut ListNode<RecvWaitQueueEntry>,
                 cx: &mut Context<'_>,
             ) -> Poll<Option<T>> {
-                self.channel.try_receive(wait_node, cx)
+                self.channel.receive_or_register(wait_node, cx)
             }
 
             fn remove_receive_waiter(
@@ -531,12 +579,12 @@ mod if_alloc {
         where
             MutexType: RawMutex,
         {
-            unsafe fn try_send(
+            unsafe fn send_or_register(
                 &self,
                 wait_node: &mut ListNode<SendWaitQueueEntry<T>>,
                 cx: &mut Context<'_>,
             ) -> (Poll<()>, Option<T>) {
-                self.channel.try_send(wait_node, cx)
+                self.channel.send_or_register(wait_node, cx)
             }
 
             fn remove_send_waiter(
@@ -705,6 +753,14 @@ mod if_alloc {
                 }
             }
 
+            /// Attempt to send the value without blocking.
+            ///
+            /// This operation is not supported for unbuffered channels and will
+            /// panic if the capacity of the `RingBuf` is zero.
+            pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+                self.inner.channel.try_send(value)
+            }
+
             /// Closes the channel.
             /// All pending future send attempts will fail.
             /// Receive attempts will continue to succeed as long as there are items
@@ -726,6 +782,11 @@ mod if_alloc {
                     wait_node: ListNode::new(RecvWaitQueueEntry::new()),
                     _phantom: PhantomData,
                 }
+            }
+
+            /// Attempt to receive form the channel without blocking.
+            pub fn try_receive(&self) -> Result<T, TryReceiveError> {
+                self.inner.channel.try_receive()
             }
 
             /// Closes the channel.

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -215,7 +215,7 @@ impl<MutexType: RawMutex, T> GenericOneshotChannel<MutexType, T> {
 impl<MutexType: RawMutex, T> ChannelReceiveAccess<T>
     for GenericOneshotChannel<MutexType, T>
 {
-    unsafe fn try_receive(
+    unsafe fn receive_or_register(
         &self,
         wait_node: &mut ListNode<RecvWaitQueueEntry>,
         cx: &mut Context<'_>,
@@ -276,12 +276,12 @@ mod if_alloc {
         where
             MutexType: RawMutex,
         {
-            unsafe fn try_receive(
+            unsafe fn receive_or_register(
                 &self,
                 wait_node: &mut ListNode<RecvWaitQueueEntry>,
                 cx: &mut Context<'_>,
             ) -> Poll<Option<T>> {
-                self.channel.try_receive(wait_node, cx)
+                self.channel.receive_or_register(wait_node, cx)
             }
 
             fn remove_receive_waiter(

--- a/src/channel/oneshot_broadcast.rs
+++ b/src/channel/oneshot_broadcast.rs
@@ -224,7 +224,7 @@ impl<MutexType: RawMutex, T> ChannelReceiveAccess<T>
 where
     T: Clone,
 {
-    unsafe fn try_receive(
+    unsafe fn receive_or_register(
         &self,
         wait_node: &mut ListNode<RecvWaitQueueEntry>,
         cx: &mut Context<'_>,
@@ -287,12 +287,12 @@ mod if_alloc {
             MutexType: RawMutex,
             T: Clone,
         {
-            unsafe fn try_receive(
+            unsafe fn receive_or_register(
                 &self,
                 wait_node: &mut ListNode<RecvWaitQueueEntry>,
                 cx: &mut Context<'_>,
             ) -> Poll<Option<T>> {
-                self.channel.try_receive(wait_node, cx)
+                self.channel.receive_or_register(wait_node, cx)
             }
 
             fn remove_receive_waiter(

--- a/tests/mpmc_channel.rs
+++ b/tests/mpmc_channel.rs
@@ -754,6 +754,123 @@ macro_rules! gen_mpmc_tests {
                 assert_eq!(1, elem2.strong_count());
                 assert_eq!(1, elem3.strong_count());
             }
+
+            #[test]
+            fn buffered_starved_recv_does_not_deadlock() {
+                let channel = ChannelType::new();
+                let (waker, count) = new_count_waker();
+                let cx = &mut Context::from_waker(&waker);
+
+                // Create enough futures to starve the permits.
+                let recv_fut1 = channel.receive();
+                let recv_fut2 = channel.receive();
+                let recv_fut3 = channel.receive();
+                let recv_fut4 = channel.receive();
+                let recv_fut5 = channel.receive();
+                pin_mut!(recv_fut1, recv_fut2, recv_fut3, recv_fut4, recv_fut5);
+                assert!(recv_fut1.as_mut().poll(cx).is_pending());
+                assert!(recv_fut2.as_mut().poll(cx).is_pending());
+                assert!(recv_fut3.as_mut().poll(cx).is_pending());
+                assert!(recv_fut3.as_mut().poll(cx).is_pending());
+                assert!(recv_fut3.as_mut().poll(cx).is_pending());
+                assert_eq!(count, 0);
+
+                // Now send & recv while being starved.
+                assert_send(cx, &channel, 1);
+                assert_eq!(count, 1);
+                assert_send(cx, &channel, 2);
+                assert_eq!(count, 2);
+                assert_send(cx, &channel, 3);
+                assert_eq!(count, 3);
+
+                let send_fut4 = channel.send(4);
+                let send_fut5 = channel.send(5);
+                pin_mut!(send_fut4, send_fut5);
+
+                assert!(send_fut4.as_mut().poll(cx).is_pending());
+                assert!(send_fut5.as_mut().poll(cx).is_pending());
+
+                let recv_fut6 = channel.receive();
+                let recv_fut7 = channel.receive();
+                let recv_fut8 = channel.receive();
+                let recv_fut9 = channel.receive();
+                let recv_fut10 = channel.receive();
+                pin_mut!(
+                    recv_fut6, recv_fut7, recv_fut8, recv_fut9, recv_fut10
+                );
+
+                // Grab the buffered data.
+                assert_receive_done(cx, &mut recv_fut6, Some(1));
+                assert_eq!(count, 4);
+                assert_receive_done(cx, &mut recv_fut7, Some(2));
+                assert_eq!(count, 5);
+                assert_receive_done(cx, &mut recv_fut8, Some(3));
+
+                // Grab the pending data.
+                assert_receive_done(cx, &mut recv_fut9, Some(4));
+                assert_receive_done(cx, &mut recv_fut10, Some(5));
+                assert_eq!(count, 5);
+
+                // Do one last send & recv.
+                let recv_fut11 = channel.receive();
+                pin_mut!(recv_fut11);
+                assert!(recv_fut11.as_mut().poll(cx).is_pending());
+
+                assert_send(cx, &channel, 6);
+                assert_receive_done(cx, &mut recv_fut11, Some(6));
+                assert_eq!(count, 6);
+
+                // Now resolve the starved futures.
+                assert_send(cx, &channel, 7);
+                assert_receive_done(cx, &mut recv_fut1, Some(7));
+                assert_send(cx, &channel, 8);
+                assert_receive_done(cx, &mut recv_fut2, Some(8));
+                assert_send(cx, &channel, 9);
+                assert_receive_done(cx, &mut recv_fut3, Some(9));
+                assert_send(cx, &channel, 10);
+                assert_receive_done(cx, &mut recv_fut4, Some(10));
+                assert_send(cx, &channel, 11);
+                assert_receive_done(cx, &mut recv_fut5, Some(11));
+                assert_eq!(count, 6);
+            }
+
+            #[test]
+            fn unbuffered_starved_send_does_not_deadlock() {
+                let channel = UnbufferedChannelType::new();
+                let (waker, count) = new_count_waker();
+                let cx = &mut Context::from_waker(&waker);
+
+                // Create enough futures to starve the permits.
+                let send_fut1 = channel.send(99);
+                let send_fut2 = channel.send(111);
+                let send_fut3 = channel.send(69);
+                pin_mut!(send_fut1, send_fut2, send_fut3);
+                assert!(send_fut1.as_mut().poll(cx).is_pending());
+                assert!(send_fut2.as_mut().poll(cx).is_pending());
+                assert!(send_fut3.as_mut().poll(cx).is_pending());
+
+                assert_eq!(count, 0);
+
+                // Now send & recv while being starved.
+                let recv_fut = channel.receive();
+                pin_mut!(recv_fut);
+                assert_receive_done(cx, &mut recv_fut, Some(99));
+                assert_eq!(count, 1);
+
+                let recv_fut = channel.receive();
+                pin_mut!(recv_fut);
+                assert_receive_done(cx, &mut recv_fut, Some(111));
+                assert_eq!(count, 2);
+
+                let recv_fut = channel.receive();
+                pin_mut!(recv_fut);
+                assert_receive_done(cx, &mut recv_fut, Some(69));
+                assert_eq!(count, 3);
+
+                assert_send_done(cx, &mut send_fut1, Ok(()));
+                assert_send_done(cx, &mut send_fut2, Ok(()));
+                assert_send_done(cx, &mut send_fut3, Ok(()));
+            }
         }
     };
 }


### PR DESCRIPTION
This allows a user to attempt to send & recv without blocking.
Had to rename the methods of the ChannelSendAccess &
ChannelReceiveAccess.

Btw why use `receive` instead of `recv`?

Also I should be back on working on #12 very soon (maybe after this weekend).