### PR TITLE
Added GrowingRingBuf implementation

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -4,7 +4,7 @@ mod real_array;
 pub use real_array::RealArray;
 
 mod ring_buffer;
-pub use ring_buffer::{ArrayRingBuf, GrowingRingBuf, RingBuf};
+pub use ring_buffer::{ArrayBuf, GrowingHeapBuf, RingBuf};
 
 #[cfg(feature = "std")]
-pub use ring_buffer::HeapRingBuf;
+pub use ring_buffer::FixedHeapBuf;

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -4,7 +4,7 @@ mod real_array;
 pub use real_array::RealArray;
 
 mod ring_buffer;
-pub use ring_buffer::{ArrayRingBuf, RingBuf};
+pub use ring_buffer::{ArrayRingBuf, GrowingRingBuf, RingBuf};
 
 #[cfg(feature = "std")]
 pub use ring_buffer::HeapRingBuf;

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -483,7 +483,6 @@ mod if_alloc {
     /// parameter.
     pub mod shared {
         use super::*;
-        use crate::buffer::FixedHeapBuf;
         use crate::channel::shared::{ChannelReceiveFuture, ChannelSendFuture};
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -763,39 +762,41 @@ mod if_alloc {
 
             /// A [`GenericSender`] implementation backed by [`parking_lot`].
             ///
-            /// Uses a `FixedHeapBuf` which allocates the capacity ahead of time.
-            /// Refer to [`FixedHeapBuf`] for more information.
+            /// Uses a `GrowingHeapBuf` whose capacity grows dynamically up to
+            /// the given limit. Refer to [`GrowingHeapBuf`] for more information.
             ///
-            /// [`FixedHeapBuf`]: ../../buffer/struct.FixedHeapBuf.html
+            /// [`GrowingHeapBuf`]: ../../buffer/struct.GrowingHeapBuf.html
             pub type Sender<T> =
-                GenericSender<parking_lot::RawMutex, T, FixedHeapBuf<T>>;
+                GenericSender<parking_lot::RawMutex, T, GrowingHeapBuf<T>>;
             /// A [`GenericReceiver`] implementation backed by [`parking_lot`].
             ///
-            /// Uses a `FixedHeapBuf` which allocates the capacity ahead of time.
-            /// Refer to [`FixedHeapBuf`] for more information.
+            /// Uses a `GrowingHeapBuf` whose capacity grows dynamically up to
+            /// the given limit. Refer to [`GrowingHeapBuf`] for more information.
             ///
-            /// [`FixedHeapBuf`]: ../../buffer/struct.FixedHeapBuf.html
+            /// [`GrowingHeapBuf`]: ../../buffer/struct.GrowingHeapBuf.html
             pub type Receiver<T> =
-                GenericReceiver<parking_lot::RawMutex, T, FixedHeapBuf<T>>;
+                GenericReceiver<parking_lot::RawMutex, T, GrowingHeapBuf<T>>;
 
-            /// Creates a new channel.
+            /// Creates a new channel with the given buffering capacity
             ///
-            /// Refer to [`generic_channel`] for details.
+            /// Uses a `GrowingHeapBuf` whose capacity grows dynamically up to
+            /// the given limit. Refer to [`generic_channel`] and [`GrowingHeapBuf`] for more information.
+            ///
+            /// [`GrowingHeapBuf`]: ../../buffer/struct.GrowingHeapBuf.html
             pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>)
             where
                 T: Send,
             {
-                generic_channel::<parking_lot::RawMutex, T, FixedHeapBuf<T>>(
+                generic_channel::<parking_lot::RawMutex, T, GrowingHeapBuf<T>>(
                     capacity,
                 )
             }
-
             /// A [`GenericSender`] implementation backed by [`parking_lot`].
             pub type UnbufferedSender<T> =
-                GenericSender<parking_lot::RawMutex, T, FixedHeapBuf<T>>;
+                GenericSender<parking_lot::RawMutex, T, GrowingHeapBuf<T>>;
             /// A [`GenericReceiver`] implementation backed by [`parking_lot`].
             pub type UnbufferedReceiver<T> =
-                GenericReceiver<parking_lot::RawMutex, T, FixedHeapBuf<T>>;
+                GenericReceiver<parking_lot::RawMutex, T, GrowingHeapBuf<T>>;
 
             /// Creates a new unbuffered channel.
             ///
@@ -804,37 +805,8 @@ mod if_alloc {
             where
                 T: Send,
             {
-                generic_channel::<parking_lot::RawMutex, T, FixedHeapBuf<T>>(0)
-            }
-
-            /// A [`GenericSender`] implementation backed by [`parking_lot`].
-            ///
-            /// Uses a `GrowingHeapBuf` whose capacity grows dynamically up to
-            /// the given limit. Refer to [`GrowingHeapBuf`] for more information.
-            ///
-            /// [`GrowingHeapBuf`]: ../../buffer/struct.GrowingHeapBuf.html
-            pub type GrowingSender<T> =
-                GenericSender<parking_lot::RawMutex, T, GrowingHeapBuf<T>>;
-            /// A [`GenericReceiver`] implementation backed by [`parking_lot`].
-            ///
-            /// Uses a `GrowingHeapBuf` whose capacity grows dynamically up to
-            /// the given limit. Refer to [`GrowingHeapBuf`] for more information.
-            ///
-            /// [`GrowingHeapBuf`]: ../../buffer/struct.GrowingHeapBuf.html
-            pub type GrowingReceiver<T> =
-                GenericReceiver<parking_lot::RawMutex, T, GrowingHeapBuf<T>>;
-
-            /// Creates a new growing channel.
-            ///
-            /// Refer to [`generic_channel`] for details.
-            pub fn growing_channel<T>(
-                capacity: usize,
-            ) -> (GrowingSender<T>, GrowingReceiver<T>)
-            where
-                T: Send,
-            {
                 generic_channel::<parking_lot::RawMutex, T, GrowingHeapBuf<T>>(
-                    capacity,
+                    0,
                 )
             }
         }


### PR DESCRIPTION
This allows user to have channel whose capacity grows over time
up to a certain limit.

This is a breaking change. Maybe defaulting the generic `RingBuf` parameter to `HeapRingBuf` would make it not breaking, but i'm not sure that's wise.

On a side note, I kinda feel like the `RingBuf` trait `capacity` term is confusing because when the term is used in the std lib it implies that it is growable. For instance in this specific PR the `capacity` (as in elements limit) of the `GrowingRingBuf` is fixed yet the `capacity` (as in allocated mem) grows as needed. I think it should be renamed to something more fitting like `limit` or `max_size` to avoid confusion.

Fixes #15.