### PR TITLE
Update stored Wakers if polled again

### DIFF
--- a/benches/mpmc_channel.rs
+++ b/benches/mpmc_channel.rs
@@ -153,7 +153,7 @@ fn futchan_bounded_variable_tx_single_thread(producers: usize) {
                     tx.send(4).await.unwrap();
                 }
             }
-                .boxed()
+            .boxed()
         }));
 
         drop(tx);
@@ -184,7 +184,7 @@ fn tokiochan_bounded_variable_tx_single_thread(producers: usize) {
                     tx.send(4).await.unwrap();
                 }
             }
-                .boxed()
+            .boxed()
         }));
 
         drop(tx);

--- a/benches/mpmc_channel.rs
+++ b/benches/mpmc_channel.rs
@@ -153,7 +153,7 @@ fn futchan_bounded_variable_tx_single_thread(producers: usize) {
                     tx.send(4).await.unwrap();
                 }
             }
-            .boxed()
+                .boxed()
         }));
 
         drop(tx);
@@ -184,7 +184,7 @@ fn tokiochan_bounded_variable_tx_single_thread(producers: usize) {
                     tx.send(4).await.unwrap();
                 }
             }
-            .boxed()
+                .boxed()
         }));
 
         drop(tx);

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -5,8 +5,11 @@ use super::{
     ChannelReceiveAccess, ChannelReceiveFuture, RecvPollState,
     RecvWaitQueueEntry,
 };
-use crate::intrusive_singly_linked_list::{LinkedList, ListNode};
-use crate::NoopLock;
+use crate::{
+    intrusive_singly_linked_list::{LinkedList, ListNode},
+    utils::update_waker_ref,
+    NoopLock,
+};
 use core::marker::PhantomData;
 use futures_core::task::{Context, Poll};
 use lock_api::{Mutex, RawMutex};
@@ -116,8 +119,11 @@ impl<T> ChannelState<T> {
                 }
             }
             RecvPollState::Registered => {
-                // Since the channel wakes up all waiters and moves their states to unregistered
-                // there can't be any value in the channel in this state.
+                // Since the channel wakes up all waiters and moves their states
+                // to unregistered there can't be any value in the channel in this state.
+                // However the caller might have passed a different `Waker`.
+                // In this case we need to update it.
+                update_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
             RecvPollState::Notified => {

--- a/src/channel/oneshot_broadcast.rs
+++ b/src/channel/oneshot_broadcast.rs
@@ -6,8 +6,11 @@ use super::{
     ChannelReceiveAccess, ChannelReceiveFuture, RecvPollState,
     RecvWaitQueueEntry,
 };
-use crate::intrusive_singly_linked_list::{LinkedList, ListNode};
-use crate::NoopLock;
+use crate::{
+    intrusive_singly_linked_list::{LinkedList, ListNode},
+    utils::update_waker_ref,
+    NoopLock,
+};
 use core::marker::PhantomData;
 use futures_core::task::{Context, Poll};
 use lock_api::{Mutex, RawMutex};
@@ -121,8 +124,11 @@ where
                 }
             }
             RecvPollState::Registered => {
-                // Since the channel wakes up all waiters and moves their states to unregistered
-                // there can't be any value in the channel in this state.
+                // Since the channel wakes up all waiters and moves their states
+                // to unregistered there can't be any value in the channel in this state.
+                // However the caller might have passed a different `Waker`.
+                // In this case we need to update it.
+                update_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
             RecvPollState::Notified => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,3 +228,5 @@ mod intrusive_singly_linked_list;
 pub mod channel;
 pub mod sync;
 pub mod timer;
+
+mod utils;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,14 @@
+//! Utilities which are used within the library
+
+use core::task::{Context, Waker};
+
+/// Updates a `Waker` which is stored inside a `Option` to the newest value
+/// which is delivered via a `Context`.
+pub fn update_waker_ref(waker_option: &mut Option<Waker>, cx: &Context) {
+    if waker_option
+        .as_ref()
+        .map_or(true, |stored_waker| !stored_waker.will_wake(cx.waker()))
+    {
+        *waker_option = Some(cx.waker().clone());
+    }
+}

--- a/tests/state_broadcast_channel.rs
+++ b/tests/state_broadcast_channel.rs
@@ -304,6 +304,27 @@ macro_rules! gen_state_broadcast_tests {
 
                 assert_eq!(count, 4);
             }
+
+            #[test]
+            fn poll_from_multiple_executors() {
+                let (waker_1, count_1) = new_count_waker();
+                let (waker_2, count_2) = new_count_waker();
+                let channel = ChannelType::new();
+
+                let cx_1 = &mut Context::from_waker(&waker_1);
+                let cx_2 = &mut Context::from_waker(&waker_2);
+
+                let fut = channel.receive(Default::default());
+                pin_mut!(fut);
+                assert!(fut.as_mut().poll(cx_1).is_pending());
+                assert!(fut.as_mut().poll(cx_2).is_pending());
+
+                assert_send(&channel, 99);
+                assert_eq!(count_1, 0);
+                assert_eq!(count_2, 1);
+
+                let _next_state_id = assert_receive_value(cx_2, &mut fut, 99);
+            }
         }
     };
 }


### PR DESCRIPTION
If Futures are polled multiple times while not being able to make
progress, we need to update the stored Waker. It is allowed to pass
a different Waker to each poll call, and we should make sure to store
the last Waker in order to properly unblock tasks.

Fixes #18