### PR TITLE
Import `PhantomData` from `core` instead of `std`

### DIFF
--- a/src/channel/state_broadcast.rs
+++ b/src/channel/state_broadcast.rs
@@ -6,13 +6,13 @@ use crate::{
     utils::update_waker_ref,
     NoopLock,
 };
+use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::{
     future::{FusedFuture, Future},
     task::{Context, Poll, Waker},
 };
 use lock_api::{Mutex, RawMutex};
-use core::marker::PhantomData;
 
 /// An ID, which allows to differentiate states received from a Channel.
 /// Elements with a bigger state ID (`id > otherId`) have been published more

--- a/src/channel/state_broadcast.rs
+++ b/src/channel/state_broadcast.rs
@@ -12,7 +12,7 @@ use futures_core::{
     task::{Context, Poll, Waker},
 };
 use lock_api::{Mutex, RawMutex};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// An ID, which allows to differentiate states received from a Channel.
 /// Elements with a bigger state ID (`id > otherId`) have been published more


### PR DESCRIPTION
Only affects `state_broadcast.rs` for no_std.