### PR TITLE
Updated mpmc Channel::close method signature

### DIFF
--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -40,7 +40,9 @@ pub use self::state_broadcast::StateBroadcastChannel;
 
 mod mpmc;
 
-pub use self::mpmc::{GenericChannel, LocalChannel, LocalUnbufferedChannel};
+pub use self::mpmc::{
+    CloseStatus, GenericChannel, LocalChannel, LocalUnbufferedChannel,
+};
 
 #[cfg(feature = "std")]
 pub use self::mpmc::{Channel, UnbufferedChannel};


### PR DESCRIPTION
The Channel::close method now returns `PrevState`, which
represents the previous state of the channel prior to being
closed.

This closes #25.