### PR TITLE
Updated {Oneshot,Broadcast}Channel::close signature

### DIFF
--- a/src/channel/channel_future.rs
+++ b/src/channel/channel_future.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll, Waker};
 
-/// Conveys additionnal information regarding the status of a channel
+/// Conveys additional information regarding the status of a channel
 /// following a `close` operation.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum CloseStatus {

--- a/src/channel/channel_future.rs
+++ b/src/channel/channel_future.rs
@@ -5,6 +5,35 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll, Waker};
 
+/// Conveys additionnal information regarding the status of a channel
+/// following a `close` operation.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum CloseStatus {
+    /// The channel has just been closed by the operation.
+    NewlyClosed,
+
+    /// The channel was already closed prior to the operation.
+    AlreadyClosed,
+}
+
+impl CloseStatus {
+    /// Returns whether the value is the `NewlyClosed` variant.
+    pub fn is_newly_closed(self) -> bool {
+        match self {
+            Self::NewlyClosed => true,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the value is the `AlreadyClosed` variant.
+    pub fn is_already_closed(self) -> bool {
+        match self {
+            Self::AlreadyClosed => true,
+            _ => false,
+        }
+    }
+}
+
 /// Tracks how the future had interacted with the channel
 #[derive(PartialEq, Debug)]
 pub enum RecvPollState {

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -8,8 +8,8 @@ pub use self::error::{ChannelSendError, TryReceiveError, TrySendError};
 
 mod channel_future;
 use channel_future::{
-    ChannelReceiveAccess, ChannelSendAccess, RecvPollState, RecvWaitQueueEntry,
-    SendPollState, SendWaitQueueEntry,
+    ChannelReceiveAccess, ChannelSendAccess, CloseStatus, RecvPollState,
+    RecvWaitQueueEntry, SendPollState, SendWaitQueueEntry,
 };
 pub use channel_future::{ChannelReceiveFuture, ChannelSendFuture};
 
@@ -40,9 +40,7 @@ pub use self::state_broadcast::StateBroadcastChannel;
 
 mod mpmc;
 
-pub use self::mpmc::{
-    CloseStatus, GenericChannel, LocalChannel, LocalUnbufferedChannel,
-};
+pub use self::mpmc::{GenericChannel, LocalChannel, LocalUnbufferedChannel};
 
 #[cfg(feature = "std")]
 pub use self::mpmc::{Channel, UnbufferedChannel};

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -16,8 +16,8 @@ use lock_api::{Mutex, RawMutex};
 
 use super::{
     ChannelReceiveAccess, ChannelReceiveFuture, ChannelSendAccess,
-    ChannelSendFuture, RecvPollState, RecvWaitQueueEntry, SendPollState,
-    SendWaitQueueEntry, TryReceiveError, TrySendError,
+    ChannelSendFuture, CloseStatus, RecvPollState, RecvWaitQueueEntry,
+    SendPollState, SendWaitQueueEntry, TryReceiveError, TrySendError,
 };
 
 fn wake_recv_waiters(waiters: LinkedList<RecvWaitQueueEntry>) {
@@ -65,35 +65,6 @@ fn wakeup_last_receive_waiter(waiters: &mut LinkedList<RecvWaitQueueEntry>) {
             if let Some(handle) = (*last_waiter).task.take() {
                 handle.wake();
             }
-        }
-    }
-}
-
-/// Conveys additionnal information regarding the status of a channel
-/// following a `close` operation.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum CloseStatus {
-    /// The channel has just been closed by the operation.
-    NewlyClosed,
-
-    /// The channel was already closed prior to the operation.
-    AlreadyClosed,
-}
-
-impl CloseStatus {
-    /// Returns whether the value is the `NewlyClosed` variant.
-    pub fn is_newly_closed(self) -> bool {
-        match self {
-            Self::NewlyClosed => true,
-            _ => false,
-        }
-    }
-
-    /// Returns whether the value is the `AlreadyClosed` variant.
-    pub fn is_already_closed(self) -> bool {
-        match self {
-            Self::AlreadyClosed => true,
-            _ => false,
         }
     }
 }

--- a/tests/oneshot_channel.rs
+++ b/tests/oneshot_channel.rs
@@ -31,8 +31,17 @@ macro_rules! gen_oneshot_tests {
             #[test]
             fn send_on_closed_channel() {
                 let channel = $channel_type::<i32>::new();
-                channel.close();
+                assert!(channel.close().is_newly_closed());
                 assert_eq!(Err(ChannelSendError(5)), channel.send(5));
+            }
+
+            #[test]
+            fn close_status() {
+                let channel = $channel_type::<i32>::new();
+
+                assert!(channel.close().is_newly_closed());
+                assert!(channel.close().is_already_closed());
+                assert!(channel.close().is_already_closed());
             }
 
             #[test]
@@ -49,7 +58,7 @@ macro_rules! gen_oneshot_tests {
                 assert!(fut2.as_mut().poll(cx).is_pending());
                 assert_eq!(count, 0);
 
-                channel.close();
+                assert!(channel.close().is_newly_closed());
                 assert_eq!(count, 2);
                 assert_receive_done(cx, &mut fut, None);
                 assert_receive_done(cx, &mut fut2, None);

--- a/tests/state_broadcast_channel.rs
+++ b/tests/state_broadcast_channel.rs
@@ -66,9 +66,18 @@ macro_rules! gen_state_broadcast_tests {
             }
 
             #[test]
+            fn close_status() {
+                let channel = ChannelType::new();
+                assert!(channel.close().is_newly_closed());
+                assert!(channel.close().is_already_closed());
+                assert!(channel.close().is_already_closed());
+                assert!(channel.close().is_already_closed());
+            }
+
+            #[test]
             fn send_on_closed_channel() {
                 let channel = ChannelType::new();
-                channel.close();
+                assert!(channel.close().is_newly_closed());
                 assert_eq!(Err(ChannelSendError(5)), channel.send(5));
             }
 
@@ -86,7 +95,7 @@ macro_rules! gen_state_broadcast_tests {
                 assert!(fut2.as_mut().poll(cx).is_pending());
                 assert_eq!(count, 0);
 
-                channel.close();
+                assert!(channel.close().is_newly_closed());
                 assert_eq!(count, 2);
                 assert_receive_closed(cx, &mut fut);
                 assert_receive_closed(cx, &mut fut2);
@@ -108,7 +117,7 @@ macro_rules! gen_state_broadcast_tests {
                 assert_send(&channel, 5);
                 assert_send(&channel, 6);
                 assert_send(&channel, 7);
-                channel.close();
+                assert!(channel.close().is_newly_closed());
 
                 assert_receive!(cx, &channel, 7, state_id);
                 assert_receive!(cx, &channel, 7, state_id);
@@ -184,7 +193,7 @@ macro_rules! gen_state_broadcast_tests {
                 let fut31 = channel.receive(state_id_3);
                 pin_mut!(fut31);
                 assert!(fut31.as_mut().poll(cx).is_pending());
-                channel.close();
+                assert!(channel.close().is_newly_closed());
                 assert_receive_closed(cx, &mut fut31);
             }
 


### PR DESCRIPTION
Oneshot & broadcast channels now return `CloseStatus` when
`close` is called, which allows the user to know if the
channel was already closed.

This is a continuation of #26 for the remaining channel implementations.