### PR TITLE
Implement TimerService with an intrusive pairing heap.

### DIFF
--- a/src/intrusive_double_linked_list.rs
+++ b/src/intrusive_double_linked_list.rs
@@ -81,56 +81,6 @@ impl<T> LinkedList<T> {
         }
     }
 
-    /// Inserts a node into the list in a way that the list keeps being sorted.
-    /// Safety: This function is only safe as long as `node` is guaranteed to
-    /// get removed from the list before it gets moved or dropped.
-    /// In addition to this `node` may not be added to another other list before
-    /// it is removed from the current one.
-    pub unsafe fn add_sorted(&mut self, node: &mut ListNode<T>)
-    where
-        T: PartialOrd,
-    {
-        if self.head.is_none() {
-            // First node in the list
-            self.head = Some(node.into());
-            self.tail = Some(node.into());
-            return;
-        }
-
-        let mut prev: Option<NonNull<ListNode<T>>> = None;
-        let mut current = self.head;
-
-        while let Some(mut current_node) = current {
-            if node.data < current_node.as_ref().data {
-                // Need to insert before the current node
-                current_node.as_mut().prev = Some(node.into());
-                match prev {
-                    Some(mut prev) => {
-                        prev.as_mut().next = Some(node.into());
-                    }
-                    None => {
-                        // We are inserting at the beginning of the list
-                        self.head = Some(node.into());
-                    }
-                }
-                node.next = current;
-                node.prev = prev;
-                return;
-            }
-            prev = current;
-            current = current_node.as_ref().next;
-        }
-
-        // We looped through the whole list and the nodes data is bigger or equal
-        // than everything we found up to now.
-        // Insert at the end. Since we checked before that the list isn't empty,
-        // tail always has a value.
-        node.prev = self.tail;
-        node.next = None;
-        self.tail.as_mut().unwrap().as_mut().next = Some(node.into());
-        self.tail = Some(node.into());
-    }
-
     /// Returns the first node in the linked list without removing it from the list
     /// The function is only safe as long as valid pointers are stored inside
     /// the linked list.
@@ -400,74 +350,6 @@ mod tests {
             setup(&mut list);
             let items: Vec<i32> = collect_reverse_list(list);
             assert_eq!([31, 7, 5].to_vec(), items);
-        }
-    }
-
-    #[test]
-    fn add_sorted() {
-        unsafe {
-            let mut a = ListNode::new(5);
-            let mut b = ListNode::new(7);
-            let mut c = ListNode::new(31);
-            let mut d = ListNode::new(99);
-
-            let mut list = LinkedList::new();
-            list.add_sorted(&mut a);
-            let items: Vec<i32> = collect_list(list);
-            assert_eq!([5].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            list.add_sorted(&mut a);
-            let items: Vec<i32> = collect_reverse_list(list);
-            assert_eq!([5].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut d, &mut c, &mut b]);
-            list.add_sorted(&mut a);
-            let items: Vec<i32> = collect_list(list);
-            assert_eq!([5, 7, 31, 99].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut d, &mut c, &mut b]);
-            list.add_sorted(&mut a);
-            let items: Vec<i32> = collect_reverse_list(list);
-            assert_eq!([99, 31, 7, 5].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut d, &mut c, &mut a]);
-            list.add_sorted(&mut b);
-            let items: Vec<i32> = collect_list(list);
-            assert_eq!([5, 7, 31, 99].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut d, &mut c, &mut a]);
-            list.add_sorted(&mut b);
-            let items: Vec<i32> = collect_reverse_list(list);
-            assert_eq!([99, 31, 7, 5].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut d, &mut b, &mut a]);
-            list.add_sorted(&mut c);
-            let items: Vec<i32> = collect_list(list);
-            assert_eq!([5, 7, 31, 99].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut d, &mut b, &mut a]);
-            list.add_sorted(&mut c);
-            let items: Vec<i32> = collect_reverse_list(list);
-            assert_eq!([99, 31, 7, 5].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut c, &mut b, &mut a]);
-            list.add_sorted(&mut d);
-            let items: Vec<i32> = collect_list(list);
-            assert_eq!([5, 7, 31, 99].to_vec(), items);
-
-            let mut list = LinkedList::new();
-            add_nodes(&mut list, &mut [&mut c, &mut b, &mut a]);
-            list.add_sorted(&mut d);
-            let items: Vec<i32> = collect_reverse_list(list);
-            assert_eq!([99, 31, 7, 5].to_vec(), items);
         }
     }
 

--- a/src/intrusive_pairing_heap.rs
+++ b/src/intrusive_pairing_heap.rs
@@ -1,0 +1,402 @@
+//! Implements an intrusive priority queue based on a pairing heap.
+
+use core::{
+    marker::PhantomPinned,
+    mem,
+    ops::{Deref, DerefMut, Drop},
+    ptr::NonNull,
+};
+
+/// Compares `a` and `b` without unwinding.
+/// This is necessary to avoid reentrancy in the heap.
+fn safe_lesser<T: Ord>(a: &T, b: &T) -> bool {
+    struct DropBomb;
+    impl Drop for DropBomb {
+        fn drop(&mut self) {
+            panic!("Panicked while comparing");
+        }
+    }
+    // If `T::cmp` panics, force a double-panic (and therefore an abort).
+    let bomb = DropBomb;
+    let ordering = a < b;
+    mem::forget(bomb);
+    ordering
+}
+
+/// A node which carries data of type `T` and is stored in an intrusive heap.
+#[derive(Debug)]
+pub struct HeapNode<T> {
+    /// The parent. `None` if this is the root.
+    parent: Option<NonNull<HeapNode<T>>>,
+    /// The previous sibling. `None` if there is no previous sibling.
+    prev: Option<NonNull<HeapNode<T>>>,
+    /// The next sibling. `None` if there is no next sibling.
+    next: Option<NonNull<HeapNode<T>>>,
+    /// The first child. `None` if there are no children.
+    first_child: Option<NonNull<HeapNode<T>>>,
+    /// The data which is associated to this heap item.
+    data: T,
+    /// Prevents `HeapNode`s from being `Unpin`. They may never be moved, since
+    /// the heap semantics require addresses to be stable.
+    _pin: PhantomPinned,
+}
+
+impl<T> HeapNode<T> {
+    /// Creates a new node with the associated data
+    pub fn new(data: T) -> HeapNode<T> {
+        HeapNode::<T> {
+            parent: None,
+            prev: None,
+            next: None,
+            first_child: None,
+            data,
+            _pin: PhantomPinned,
+        }
+    }
+
+    fn is_root(&self) -> bool {
+        if self.parent.is_none() {
+            debug_assert_eq!(self.prev, None);
+            debug_assert_eq!(self.next, None);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<T> Deref for HeapNode<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for HeapNode<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+}
+
+/// Add a child to a node.
+unsafe fn add_child<T: Ord>(
+    mut parent: NonNull<HeapNode<T>>,
+    mut child: NonNull<HeapNode<T>>,
+) {
+    // require parent <= child
+    debug_assert!(!safe_lesser(&child.as_ref().data, &parent.as_ref().data));
+    if let Some(mut old_first_child) = parent.as_mut().first_child.take() {
+        child.as_mut().next = Some(old_first_child);
+        old_first_child.as_mut().prev = Some(child);
+    }
+    parent.as_mut().first_child = Some(child);
+    child.as_mut().parent = Some(parent);
+}
+
+/// Merge two root heaps. Returns the new root.
+unsafe fn meld<T: Ord>(
+    mut left: NonNull<HeapNode<T>>,
+    mut right: NonNull<HeapNode<T>>,
+) -> NonNull<HeapNode<T>> {
+    debug_assert!(left.as_ref().is_root());
+    debug_assert!(right.as_ref().is_root());
+    if safe_lesser(&right.as_ref().data, &left.as_ref().data) {
+        mem::swap(&mut left, &mut right);
+    }
+    // Now we always have `left` <= `right`. `left` will be the new root.
+    add_child(left, right);
+    left
+}
+
+/// Merge two root heaps, where the left might be empty. Returns the new root.
+unsafe fn maybe_meld<T: Ord>(
+    left: Option<NonNull<HeapNode<T>>>,
+    right: NonNull<HeapNode<T>>,
+) -> NonNull<HeapNode<T>> {
+    if let Some(left) = left {
+        meld(left, right)
+    } else {
+        right
+    }
+}
+
+/// Given the first child in a child list, traverse and find the last child.
+unsafe fn last_child<T>(
+    mut first_child: NonNull<HeapNode<T>>,
+) -> NonNull<HeapNode<T>> {
+    while let Some(next) = first_child.as_ref().next {
+        first_child = next;
+    }
+    first_child
+}
+
+unsafe fn unlink_prev<T>(
+    mut node: NonNull<HeapNode<T>>,
+) -> Option<NonNull<HeapNode<T>>> {
+    let mut prev = node.as_mut().prev.take()?;
+    debug_assert_eq!(prev.as_ref().next, Some(node));
+    prev.as_mut().next = None;
+    Some(prev)
+}
+
+/// Merge together a child list. Each child in the child list is expected to
+/// have an equal `parent`. Returns the new merged root, whose `parent` will be unset.
+unsafe fn merge_children<T: Ord>(
+    first_child: NonNull<HeapNode<T>>,
+) -> NonNull<HeapNode<T>> {
+    let common_parent = first_child.as_ref().parent;
+    debug_assert!(common_parent.is_some());
+
+    // Traverse the children right-to-left. This is important for the analysis
+    // to work. Reading: "Pairing heaps: the forward variant",
+    // https://arxiv.org/pdf/1709.01152.pdf
+    let mut node = last_child(first_child);
+    let mut current = None;
+    // Loop invariant: `node` is the first unprocessed child, `current`
+    // is the merged result of all processed children.
+    loop {
+        // All nodes in the list should have the same parent.
+        let node_parent = node.as_mut().parent.take();
+        debug_assert_eq!(node_parent, common_parent);
+
+        // Grab the last two unprocessed elements.
+        let mut prev = if let Some(prev) = unlink_prev(node) {
+            prev
+        } else {
+            // Odd case.
+            return maybe_meld(current, node);
+        };
+
+        // All nodes in the list should have the same parent.
+        let prev_parent = prev.as_mut().parent.take();
+        debug_assert_eq!(prev_parent, common_parent);
+
+        // Unlink `prev` from `prev.prev`.
+        let prev_prev = unlink_prev(prev);
+
+        // Meld the pair, then meld it into the accumulator.
+        let cur = maybe_meld(current, meld(prev, node));
+
+        if let Some(prev_prev) = prev_prev {
+            node = prev_prev;
+            current = Some(cur);
+            continue;
+        } else {
+            // Even case.
+            return cur;
+        }
+    }
+}
+
+/// An intrusive min-heap of nodes, where each node carries associated data
+/// of type `T`.
+#[derive(Debug)]
+pub struct PairingHeap<T> {
+    root: Option<NonNull<HeapNode<T>>>,
+}
+
+impl<T: Ord> PairingHeap<T> {
+    /// Creates an empty heap
+    pub fn new() -> Self {
+        PairingHeap::<T> { root: None }
+    }
+
+    /// Adds a node to the heap.
+    /// Safety: This function is only safe as long as `node` is guaranteed to
+    /// get removed from the list before it gets moved or dropped.
+    /// In addition to this `node` may not be added to another other heap before
+    /// it is removed from the current one.
+    pub unsafe fn insert(&mut self, node: &mut HeapNode<T>) {
+        // The node should not already be in a heap.
+        debug_assert!(node.is_root());
+        debug_assert_eq!(node.first_child, None);
+
+        if let Some(root) = self.root {
+            self.root = Some(meld(root, node.into()));
+        } else {
+            self.root = Some(node.into());
+        }
+    }
+
+    /// Returns the smallest element in the heap without removing it.
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the heap.
+    /// The returned pointer is only guaranteed to be valid as long as the heap
+    /// is not mutated
+    pub fn peek_min(&self) -> Option<NonNull<HeapNode<T>>> {
+        self.root
+    }
+
+    /// Removes the given node from the heap.
+    /// The node must be a member of this heap, and not a member of any other
+    /// heap.
+    pub unsafe fn remove(&mut self, node: &mut HeapNode<T>) {
+        let parent = node.parent.take();
+        if let Some(mut parent) = parent {
+            // Unlink this node from its parent.
+            if let Some(mut prev) = node.prev {
+                prev.as_mut().next = node.next;
+            } else {
+                parent.as_mut().first_child = node.next;
+            }
+            if let Some(mut next) = node.next {
+                next.as_mut().prev = node.prev;
+            }
+            node.next = None;
+            node.prev = None;
+        } else {
+            debug_assert_eq!(node.next, None);
+            debug_assert_eq!(node.prev, None);
+            debug_assert_eq!(self.root, Some(node.into()));
+            self.root = None;
+        }
+        if let Some(first_child) = node.first_child.take() {
+            // Merge together the children.
+            let children = merge_children(first_child);
+            // Add the children back into the parent.
+            if let Some(parent) = parent {
+                // The heap property is preserved because we had `parent.data`
+                // <= `node.data`, and `node.data` <= `child.data` for all
+                // children.
+                add_child(parent, children);
+            } else {
+                self.root = Some(children);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::{HeapNode, PairingHeap};
+    use core::ptr::NonNull;
+
+    // Recursively check the provided node and all descendants for:
+    // - pointer consistency: parent pointers and next/prev
+    // - the heap property: `node.data <= child.data` for all children
+    unsafe fn validate_heap_node<T: Ord>(
+        node: &HeapNode<T>,
+        parent: Option<&HeapNode<T>>,
+    ) {
+        assert_eq!(node.parent, parent.map(NonNull::from));
+        if let Some(p) = parent {
+            assert!(p.data <= node.data);
+        }
+        if let Some(prev) = node.prev {
+            assert_eq!(prev.as_ref().next, Some(node.into()));
+        }
+        if let Some(next) = node.next {
+            assert_eq!(next.as_ref().prev, Some(node.into()));
+        }
+        let mut child = node.first_child;
+        while let Some(c) = child {
+            validate_heap_node(c.as_ref(), Some(node));
+            child = c.as_ref().next;
+        }
+    }
+
+    fn validate_heap<T: Ord>(heap: &PairingHeap<T>) {
+        if let Some(root) = heap.root {
+            // This is also sufficient to check that `heap.root` is indeed a
+            // minimum element of the heap.
+            unsafe {
+                validate_heap_node(root.as_ref(), None);
+            }
+        }
+    }
+
+    #[test]
+    fn insert_and_remove() {
+        // This test exhaustively covers every possible schedule of inserting,
+        // then removing, each of five different nodes from the heap.
+        #[derive(Copy, Clone, Debug)]
+        enum Action {
+            Insert(u8),
+            Remove(u8),
+        }
+        fn generate_schedules(
+            current: &mut Vec<Action>,
+            available: &mut Vec<Action>,
+            f: fn(&[Action]),
+        ) {
+            for i in 0..available.len() {
+                let action = available.swap_remove(i);
+                current.push(action);
+                f(current);
+                if let Action::Insert(j) = action {
+                    available.push(Action::Remove(j));
+                }
+                generate_schedules(current, available, f);
+                if let Action::Insert(_) = action {
+                    available.pop();
+                }
+                current.pop();
+                // the opposite of `swap_remove`
+                available.push(action);
+                let len = available.len();
+                available.swap(i, len - 1);
+            }
+        }
+        let max = if cfg!(miri) {
+            // Miri is really slow, make things easier.
+            3
+        } else {
+            // 5 runs in a reasonable amount of time but still exercises
+            // interesting cases.
+            5
+        };
+        generate_schedules(
+            &mut vec![],
+            &mut (0..max).map(Action::Insert).collect(),
+            |schedule| unsafe {
+                let mut nodes = [
+                    HeapNode::new(0u8),
+                    HeapNode::new(1),
+                    HeapNode::new(2),
+                    HeapNode::new(3),
+                    HeapNode::new(4),
+                ];
+                let mut heap = PairingHeap::new();
+                for action in schedule {
+                    match *action {
+                        Action::Insert(n) => {
+                            heap.insert(&mut nodes[n as usize]);
+                            validate_heap(&heap);
+                        }
+                        Action::Remove(n) => {
+                            heap.remove(&mut nodes[n as usize]);
+                            assert!(nodes[n as usize].is_root());
+                            assert_eq!(nodes[n as usize].first_child, None);
+                            validate_heap(&heap);
+                        }
+                    }
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn equal_values() {
+        // Check that things behave properly in the presence of equal values.
+        unsafe {
+            let mut nodes = [
+                HeapNode::new(0u8),
+                HeapNode::new(0),
+                HeapNode::new(0),
+                HeapNode::new(0),
+                HeapNode::new(0),
+            ];
+            let mut heap = PairingHeap::new();
+            for node in &mut nodes {
+                heap.insert(node);
+                validate_heap(&heap);
+            }
+            for _ in 0..5 {
+                heap.remove(heap.peek_min().unwrap().as_mut());
+                validate_heap(&heap);
+            }
+            assert_eq!(heap.peek_min(), None);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ pub mod buffer;
 
 #[allow(dead_code)]
 mod intrusive_double_linked_list;
+mod intrusive_pairing_heap;
 
 pub mod channel;
 pub mod sync;

--- a/src/timer/timer.rs
+++ b/src/timer/timer.rs
@@ -286,7 +286,6 @@ impl<MutexType: RawMutex> GenericTimerService<MutexType> {
 
     /// Returns a deadline based on the current timestamp plus the given Duration
     fn deadline_from_now(&self, duration: Duration) -> u64 {
-        // TODO: Make this more efficient and with better overflow checking
         let now = self.inner.lock().clock.now();
         let duration_ms =
             core::cmp::min(duration.as_millis(), core::u64::MAX as u128) as u64;

--- a/src/timer/timer.rs
+++ b/src/timer/timer.rs
@@ -2,7 +2,7 @@
 
 use super::clock::Clock;
 use crate::{
-    intrusive_double_linked_list::{LinkedList, ListNode},
+    intrusive_pairing_heap::{HeapNode, PairingHeap},
     utils::update_waker_ref,
     NoopLock,
 };
@@ -55,6 +55,8 @@ impl PartialEq for TimerQueueEntry {
     }
 }
 
+impl Eq for TimerQueueEntry {}
+
 impl PartialOrd for TimerQueueEntry {
     fn partial_cmp(
         &self,
@@ -65,19 +67,25 @@ impl PartialOrd for TimerQueueEntry {
     }
 }
 
+impl Ord for TimerQueueEntry {
+    fn cmp(&self, other: &TimerQueueEntry) -> core::cmp::Ordering {
+        self.expiry.cmp(&other.expiry)
+    }
+}
+
 /// Internal state of the timer
 struct TimerState {
     /// The clock which is utilized
     clock: &'static dyn Clock,
-    /// The list of waiters, which are waiting for their timer to expire
-    waiters: LinkedList<TimerQueueEntry>,
+    /// The heap of waiters, which are waiting for their timer to expire
+    waiters: PairingHeap<TimerQueueEntry>,
 }
 
 impl TimerState {
     fn new(clock: &'static dyn Clock) -> TimerState {
         TimerState {
             clock,
-            waiters: LinkedList::new(),
+            waiters: PairingHeap::new(),
         }
     }
 
@@ -86,7 +94,7 @@ impl TimerState {
     /// to be stable until it gets removed from the queue.
     unsafe fn try_wait(
         &mut self,
-        wait_node: &mut ListNode<TimerQueueEntry>,
+        wait_node: &mut HeapNode<TimerQueueEntry>,
         cx: &mut Context<'_>,
     ) -> Poll<()> {
         match wait_node.state {
@@ -100,7 +108,7 @@ impl TimerState {
                     // Added the task to the wait queue
                     wait_node.task = Some(cx.waker().clone());
                     wait_node.state = PollState::Registered;
-                    self.waiters.add_sorted(wait_node);
+                    self.waiters.insert(wait_node);
                     Poll::Pending
                 }
             }
@@ -116,17 +124,13 @@ impl TimerState {
         }
     }
 
-    fn remove_waiter(&mut self, wait_node: &mut ListNode<TimerQueueEntry>) {
+    fn remove_waiter(&mut self, wait_node: &mut HeapNode<TimerQueueEntry>) {
         // TimerFuture only needs to get removed if it had been added to
         // the wait queue of the timer. This has happened in the PollState::Registered case.
         if let PollState::Registered = wait_node.state {
             // Safety: Due to the state, we know that the node must be part
-            // of the waiter list
-            if !unsafe { self.waiters.remove(wait_node) } {
-                // Panic if the address isn't found. This can only happen if the contract was
-                // violated, e.g. the TimerQueueEntry got moved after the initial poll.
-                panic!("Future could not be removed from wait queue");
-            }
+            // of the waiter heap
+            unsafe { self.waiters.remove(wait_node) };
             wait_node.state = PollState::Unregistered;
         }
     }
@@ -136,32 +140,32 @@ impl TimerState {
     /// For thread-safe timers, the returned value is not precise and subject to
     /// race-conditions, since other threads can add timer in the meantime.
     fn next_expiration(&self) -> Option<u64> {
-        self.waiters.peek_first().map(|first| first.expiry)
+        // Safety: We ensure that any node in the heap remains alive
+        unsafe { self.waiters.peek_min().map(|first| first.as_ref().expiry) }
     }
 
     /// Checks whether any of the attached Futures is expired
     fn check_expirations(&mut self) {
         let now = self.clock.now();
-        loop {
-            match self.waiters.peek_first() {
-                None => return,
-                Some(first) => {
-                    let first_expiry = first.expiry;
-                    if now >= first_expiry {
-                        // The timer is expired.
-                        first.state = PollState::Expired;
-                        if let Some(task) = first.task.take() {
-                            task.wake();
-                        }
-                    } else {
-                        // Remaining timers are not expired
-                        break;
+        while let Some(mut first) = self.waiters.peek_min() {
+            // Safety: We ensure that any node in the heap remains alive
+            unsafe {
+                let entry = first.as_mut();
+                let first_expiry = entry.expiry;
+                if now >= first_expiry {
+                    // The timer is expired.
+                    entry.state = PollState::Expired;
+                    if let Some(task) = entry.task.take() {
+                        task.wake();
                     }
+                } else {
+                    // Remaining timers are not expired
+                    break;
                 }
-            }
 
-            // Remove the expired timer
-            self.waiters.remove_first();
+                // Remove the expired timer
+                self.waiters.remove(entry);
+            }
         }
     }
 }
@@ -171,11 +175,11 @@ impl TimerState {
 trait TimerAccess {
     unsafe fn try_wait(
         &self,
-        wait_node: &mut ListNode<TimerQueueEntry>,
+        wait_node: &mut HeapNode<TimerQueueEntry>,
         cx: &mut Context<'_>,
     ) -> Poll<()>;
 
-    fn remove_waiter(&self, wait_node: &mut ListNode<TimerQueueEntry>);
+    fn remove_waiter(&self, wait_node: &mut HeapNode<TimerQueueEntry>);
 }
 
 /// An asynchronously awaitable timer which is bound to a thread.
@@ -283,12 +287,10 @@ impl<MutexType: RawMutex> GenericTimerService<MutexType> {
     /// Returns a deadline based on the current timestamp plus the given Duration
     fn deadline_from_now(&self, duration: Duration) -> u64 {
         // TODO: Make this more efficient and with better overflow checking
-        let now = self.inner.lock().clock.now() as u128;
+        let now = self.inner.lock().clock.now();
         let duration_ms =
-            core::cmp::min(duration.as_millis(), core::u64::MAX as u128);
-        let expiry =
-            core::cmp::min(now + duration_ms, core::u64::MAX as u128) as u64;
-        expiry
+            core::cmp::min(duration.as_millis(), core::u64::MAX as u128) as u64;
+        now.saturating_add(duration_ms)
     }
 }
 
@@ -304,7 +306,7 @@ impl<MutexType: RawMutex> LocalTimer for GenericTimerService<MutexType> {
     fn deadline(&self, timestamp: u64) -> LocalTimerFuture {
         LocalTimerFuture {
             timer: Some(self),
-            wait_node: ListNode::new(TimerQueueEntry::new(timestamp)),
+            wait_node: HeapNode::new(TimerQueueEntry::new(timestamp)),
         }
     }
 }
@@ -325,7 +327,7 @@ where
         TimerFuture {
             timer_future: LocalTimerFuture {
                 timer: Some(self),
-                wait_node: ListNode::new(TimerQueueEntry::new(timestamp)),
+                wait_node: HeapNode::new(TimerQueueEntry::new(timestamp)),
             },
         }
     }
@@ -334,13 +336,13 @@ where
 impl<MutexType: RawMutex> TimerAccess for GenericTimerService<MutexType> {
     unsafe fn try_wait(
         &self,
-        wait_node: &mut ListNode<TimerQueueEntry>,
+        wait_node: &mut HeapNode<TimerQueueEntry>,
         cx: &mut Context<'_>,
     ) -> Poll<()> {
         self.inner.lock().try_wait(wait_node, cx)
     }
 
-    fn remove_waiter(&self, wait_node: &mut ListNode<TimerQueueEntry>) {
+    fn remove_waiter(&self, wait_node: &mut HeapNode<TimerQueueEntry>) {
         self.inner.lock().remove_waiter(wait_node)
     }
 }
@@ -351,7 +353,7 @@ pub struct LocalTimerFuture<'a> {
     /// The Timer that is associated with this TimerFuture
     timer: Option<&'a dyn TimerAccess>,
     /// Node for waiting on the timer
-    wait_node: ListNode<TimerQueueEntry>,
+    wait_node: HeapNode<TimerQueueEntry>,
 }
 
 impl<'a> core::fmt::Debug for LocalTimerFuture<'a> {


### PR DESCRIPTION
This makes the timer more efficient when it has many nodes (O(1) rather
than O(n) insertion, and amortized O(log n) removal).