### PR TITLE
Support changing channels capacity at runtime

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -4,7 +4,7 @@ mod real_array;
 pub use real_array::RealArray;
 
 mod ring_buffer;
-pub use ring_buffer::{ArrayBuf, RingBuf};
+pub use ring_buffer::{AdjustableRingBuffer, ArrayBuf, RingBuf};
 
 #[cfg(feature = "std")]
 pub use ring_buffer::FixedHeapBuf;

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -371,6 +371,8 @@ where
     MutexType: RawMutex,
     A: RingBuf<Item = T> + AdjustableRingBuffer,
 {
+    /// Changes the capacity of the channel in runtime. See documentation of
+    /// `set_capacity` in particular `RingBuffer` implementation
     pub fn set_capacity(&self, new_cap: usize) {
         let inner = &mut *self.inner.lock();
         if inner.buffer.set_capacity(new_cap) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@
 #![deny(bare_trait_objects)]
 
 mod noop_lock;
-use noop_lock::NoopLock;
+pub use noop_lock::NoopLock;
 
 pub mod buffer;
 


### PR DESCRIPTION
This PR introduces support to change the capacity of channels backed by heap ring buffers. In the case of network transmission, depending on the speed, there may be different requirements on buffer size. When the speed is low, it makes sense to shrink the buffer to lower memory consumption, but when it goes up, higher buffer sizes may improve the speed and stability. 