### PR TITLE
Expose channel::ChannelStream

### DIFF
--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -42,7 +42,9 @@ pub use self::state_broadcast::StateBroadcastChannel;
 
 mod mpmc;
 
-pub use self::mpmc::{GenericChannel, LocalChannel, LocalUnbufferedChannel};
+pub use self::mpmc::{
+    ChannelStream, GenericChannel, LocalChannel, LocalUnbufferedChannel,
+};
 
 #[cfg(feature = "alloc")]
 pub use self::mpmc::{Channel, UnbufferedChannel};


### PR DESCRIPTION
The `channel::mpmc::ChannelStream` type is returned by `channel::GenericChannel::stream`, but the type wasn't exposed so the return type couldn't be named. This exposes it from `channel`.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>