### PR TITLE
Add shared semaphore implementation

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -32,5 +32,8 @@ pub use self::semaphore::{
 
 #[cfg(feature = "alloc")]
 pub use self::semaphore::{
-    Semaphore, SemaphoreAcquireFuture, SemaphoreReleaser,
+    GenericSharedSemaphore, GenericSharedSemaphoreAcquireFuture,
+    GenericSharedSemaphoreReleaser, Semaphore, SemaphoreAcquireFuture,
+    SemaphoreReleaser, SharedSemaphore, SharedSemaphoreAcquireFuture,
+    SharedSemaphoreReleaser,
 };

--- a/tests/semaphore.rs
+++ b/tests/semaphore.rs
@@ -569,9 +569,10 @@ gen_semaphore_tests!(local_semaphore_tests, LocalSemaphore);
 mod if_alloc {
     use super::*;
     use futures::FutureExt;
-    use futures_intrusive::sync::Semaphore;
+    use futures_intrusive::sync::{Semaphore, SharedSemaphore};
 
     gen_semaphore_tests!(semaphore_tests, Semaphore);
+    gen_semaphore_tests!(shared_semaphore_tests, SharedSemaphore);
 
     fn is_send<T: Send>(_: &T) {}
 


### PR DESCRIPTION
This adds a shared generic semaphore implementation that can be shared across threads or futures.

My use case is a set of future ran concurrently in an executor that are each rate-limited via a shared semaphore.