### PR TITLE
Dropping the last GenericReceiver now clears the channel

### DIFF
--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -92,6 +92,12 @@ where
         }
     }
 
+    fn clear(&mut self) {
+        while !self.buffer.is_empty() {
+            self.buffer.pop();
+        }
+    }
+
     fn close(&mut self) -> CloseStatus {
         if self.is_closed {
             return CloseStatus::AlreadyClosed;
@@ -847,6 +853,10 @@ mod if_alloc {
                 // Close the channel, before last receiver gets destroyed
                 // TODO: We could potentially avoid this, if no sender is left
                 self.inner.channel.close();
+
+                // Now drop the content of the channel. This ensures that
+                // the content of the channel is dropped even if a sender is held.
+                self.inner.channel.inner.lock().clear();
             }
         }
 


### PR DESCRIPTION
This allows the content of the channel to be dropped even if all the senders are not dropped.

My specific use case is that I have a `Handle` held by a user that contains a `Sender<OneshotSender>` that is sent to the `Driver` that hold the `Receiver<OneshotSender>`. Let's say the `Driver` errors and is dropped, then the `OneshotSender` will never be dropped unless the user drops the `Handle`, which can't be forced. If the user also hold some kind of future that waits on the `OneshotSender`, this creates a deadlock.