### PR TITLE
Decouple alloc from std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
 script:
   - cargo fmt --all -- --check
   - cargo test --no-default-features
-  - cargo test --all-targets --no-default-features --features alloc
+  - cargo test --no-default-features --features alloc
   - cargo test --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ Futures based on intrusive data structures - for std and no-std environments.
 name = "futures_intrusive"
 
 [features]
-alloc = ["futures-core/alloc", "parking_lot"]
-std = ["alloc"]
+alloc = ["futures-core/alloc"]
+std = ["alloc", "parking_lot"]
 default = ["std"]
 
 [dependencies]

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -19,7 +19,7 @@ mod oneshot;
 
 pub use self::oneshot::{GenericOneshotChannel, LocalOneshotChannel};
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::oneshot::OneshotChannel;
 
 mod oneshot_broadcast;
@@ -28,7 +28,7 @@ pub use self::oneshot_broadcast::{
     GenericOneshotBroadcastChannel, LocalOneshotBroadcastChannel,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::oneshot_broadcast::OneshotBroadcastChannel;
 
 mod state_broadcast;
@@ -37,7 +37,7 @@ pub use state_broadcast::{
     StateReceiveFuture,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::state_broadcast::StateBroadcastChannel;
 
 mod mpmc;
@@ -46,7 +46,7 @@ pub use self::mpmc::{
     ChannelStream, GenericChannel, LocalChannel, LocalUnbufferedChannel,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::mpmc::{Channel, UnbufferedChannel};
 
 #[cfg(feature = "alloc")]

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -649,8 +649,8 @@ pub type LocalChannel<T, A> = GenericChannel<NoopLock, T, ArrayBuf<T, A>>;
 /// An unbuffered [`GenericChannel`] implementation which is not thread-safe.
 pub type LocalUnbufferedChannel<T> = LocalChannel<T, [T; 0]>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
 
     // Export a thread-safe version using parking_lot::RawMutex
@@ -670,6 +670,14 @@ mod if_alloc {
 
     /// An unbuffered [`GenericChannel`] implementation backed by [`parking_lot`].
     pub type UnbufferedChannel<T> = Channel<T, [T; 0]>;
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use super::*;
 
     /// Channel implementations where Sender and Receiver sides are cloneable
     /// and owned.
@@ -1069,8 +1077,8 @@ mod if_alloc {
         }
 
         // Export parking_lot based shared channels in std mode
-        #[cfg(feature = "alloc")]
-        mod if_alloc {
+        #[cfg(feature = "std")]
+        mod if_std {
             use super::*;
 
             use crate::buffer::GrowingHeapBuf;
@@ -1126,8 +1134,8 @@ mod if_alloc {
             }
         }
 
-        #[cfg(feature = "alloc")]
-        pub use self::if_alloc::*;
+        #[cfg(feature = "std")]
+        pub use self::if_std::*;
     }
 }
 

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -9,7 +9,6 @@ use crate::{
 use core::{marker::PhantomData, pin::Pin};
 use futures_core::{
     future::Future,
-    ready,
     stream::{FusedStream, Stream},
     task::{Context, Poll, Waker},
 };
@@ -879,11 +878,6 @@ mod if_alloc {
         /// itself will be closed.
         ///
         /// The channel can buffer up to `capacity` items internally.
-        ///
-        /// ```
-        /// # use futures_intrusive::channel::shared::channel;
-        /// let (sender, receiver) = channel::<i32>(4);
-        /// ```
         pub fn generic_channel<MutexType, T, A>(
             capacity: usize,
         ) -> (
@@ -1106,6 +1100,11 @@ mod if_alloc {
             /// the given limit. Refer to [`generic_channel`] and [`GrowingHeapBuf`] for more information.
             ///
             /// [`GrowingHeapBuf`]: ../../buffer/struct.GrowingHeapBuf.html
+            ///
+            /// ```
+            /// # use futures_intrusive::channel::shared::channel;
+            /// let (sender, receiver) = channel::<i32>(4);
+            /// ```
             pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>)
             where
                 T: Send,

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -232,15 +232,22 @@ impl<MutexType: RawMutex, T> ChannelReceiveAccess<T>
 /// A [`GenericOneshotChannel`] which is not thread-safe.
 pub type LocalOneshotChannel<T> = GenericOneshotChannel<NoopLock, T>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
-
     // Export a thread-safe version using parking_lot::RawMutex
 
     /// A [`GenericOneshotChannel`] implementation backed by [`parking_lot`].
     pub type OneshotChannel<T> =
         GenericOneshotChannel<parking_lot::RawMutex, T>;
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use super::*;
 
     pub mod shared {
         use super::*;
@@ -411,9 +418,9 @@ mod if_alloc {
             }
         }
 
-        // Export parking_lot based shared channels in alloc mode
-        #[cfg(feature = "alloc")]
-        mod if_alloc {
+        // Export parking_lot based shared channels in std mode
+        #[cfg(feature = "std")]
+        mod if_std {
             use super::*;
 
             /// A [`GenericOneshotSender`] implementation backed by [`parking_lot`].
@@ -434,8 +441,8 @@ mod if_alloc {
             }
         }
 
-        #[cfg(feature = "alloc")]
-        pub use self::if_alloc::*;
+        #[cfg(feature = "std")]
+        pub use self::if_std::*;
     }
 }
 

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -360,13 +360,6 @@ mod if_alloc {
         ///
         /// As soon es either the senders or receivers is closed, the channel
         /// itself will be closed.
-        ///
-        /// Example for creating a channel to transmit an integer value:
-        ///
-        /// ```
-        /// # use futures_intrusive::channel::shared::oneshot_channel;
-        /// let (sender, receiver) = oneshot_channel::<i32>();
-        /// ```
         pub fn generic_oneshot_channel<MutexType, T>() -> (
             GenericOneshotSender<MutexType, T>,
             GenericOneshotReceiver<MutexType, T>,
@@ -433,6 +426,13 @@ mod if_alloc {
             /// Creates a new oneshot channel.
             ///
             /// Refer to [`generic_oneshot_channel`] for details.
+            ///
+            /// Example for creating a channel to transmit an integer value:
+            ///
+            /// ```
+            /// # use futures_intrusive::channel::shared::oneshot_channel;
+            /// let (sender, receiver) = oneshot_channel::<i32>();
+            /// ```
             pub fn oneshot_channel<T>() -> (OneshotSender<T>, OneshotReceiver<T>)
             where
                 T: Send,

--- a/src/channel/oneshot_broadcast.rs
+++ b/src/channel/oneshot_broadcast.rs
@@ -394,13 +394,6 @@ mod if_alloc {
         ///
         /// As soon es either the senders or all receivers is closed, the channel
         /// itself will be closed.
-        ///
-        /// Example for creating a channel to transmit an integer value:
-        ///
-        /// ```
-        /// # use futures_intrusive::channel::shared::oneshot_broadcast_channel;
-        /// let (sender, receiver) = oneshot_broadcast_channel::<i32>();
-        /// ```
         pub fn generic_oneshot_broadcast_channel<MutexType, T>() -> (
             GenericOneshotBroadcastSender<MutexType, T>,
             GenericOneshotBroadcastReceiver<MutexType, T>,
@@ -469,6 +462,13 @@ mod if_alloc {
             /// Creates a new oneshot broadcast channel.
             ///
             /// Refer to [`generic_oneshot_broadcast_channel`] for details.
+            ///
+            /// Example for creating a channel to transmit an integer value:
+            ///
+            /// ```
+            /// # use futures_intrusive::channel::shared::oneshot_broadcast_channel;
+            /// let (sender, receiver) = oneshot_broadcast_channel::<i32>();
+            /// ```
             pub fn oneshot_broadcast_channel<T>(
             ) -> (OneshotBroadcastSender<T>, OneshotBroadcastReceiver<T>)
             where

--- a/src/channel/oneshot_broadcast.rs
+++ b/src/channel/oneshot_broadcast.rs
@@ -242,8 +242,8 @@ where
 pub type LocalOneshotBroadcastChannel<T> =
     GenericOneshotBroadcastChannel<NoopLock, T>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
 
     // Export a thread-safe version using parking_lot::RawMutex
@@ -251,6 +251,14 @@ mod if_alloc {
     /// A [`GenericOneshotBroadcastChannel`] implementation backed by [`parking_lot`].
     pub type OneshotBroadcastChannel<T> =
         GenericOneshotBroadcastChannel<parking_lot::RawMutex, T>;
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use super::*;
 
     pub mod shared {
         use super::*;
@@ -446,9 +454,9 @@ mod if_alloc {
             }
         }
 
-        // Export parking_lot based shared channels in alloc mode
-        #[cfg(feature = "alloc")]
-        mod if_alloc {
+        // Export parking_lot based shared channels in std mode
+        #[cfg(feature = "std")]
+        mod if_std {
             use super::*;
 
             /// A [`GenericOneshotBroadcastSender`] implementation backed by [`parking_lot`].
@@ -470,8 +478,8 @@ mod if_alloc {
             }
         }
 
-        #[cfg(feature = "alloc")]
-        pub use self::if_alloc::*;
+        #[cfg(feature = "std")]
+        pub use self::if_std::*;
     }
 }
 

--- a/src/channel/state_broadcast.rs
+++ b/src/channel/state_broadcast.rs
@@ -428,8 +428,8 @@ impl<MutexType: RawMutex, T: Clone> ChannelReceiveAccess<T>
 pub type LocalStateBroadcastChannel<T> =
     GenericStateBroadcastChannel<NoopLock, T>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
 
     // Export a thread-safe version using parking_lot::RawMutex
@@ -437,6 +437,14 @@ mod if_alloc {
     /// A [`GenericStateBroadcastChannel`] implementation backed by [`parking_lot`].
     pub type StateBroadcastChannel<T> =
         GenericStateBroadcastChannel<parking_lot::RawMutex, T>;
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use super::*;
 
     pub mod shared {
         use super::*;
@@ -772,9 +780,9 @@ mod if_alloc {
             }
         }
 
-        // Export parking_lot based shared channels in alloc mode
-        #[cfg(feature = "alloc")]
-        mod if_alloc {
+        // Export parking_lot based shared channels in std mode
+        #[cfg(feature = "std")]
+        mod if_std {
             use super::*;
 
             /// A [`GenericStateSender`] implementation backed by [`parking_lot`].
@@ -796,8 +804,8 @@ mod if_alloc {
             }
         }
 
-        #[cfg(feature = "alloc")]
-        pub use self::if_alloc::*;
+        #[cfg(feature = "std")]
+        pub use self::if_std::*;
     }
 }
 

--- a/src/channel/state_broadcast.rs
+++ b/src/channel/state_broadcast.rs
@@ -697,13 +697,6 @@ mod if_alloc {
         ///
         /// As soon es either the senders or receivers is closed, the channel
         /// itself will be closed.
-        ///
-        /// Example for creating a channel to transmit an integer value:
-        ///
-        /// ```
-        /// # use futures_intrusive::channel::shared::state_broadcast_channel;
-        /// let (sender, receiver) = state_broadcast_channel::<i32>();
-        /// ```
         pub fn generic_state_broadcast_channel<MutexType, T>() -> (
             GenericStateSender<MutexType, T>,
             GenericStateReceiver<MutexType, T>,
@@ -795,6 +788,13 @@ mod if_alloc {
             /// Creates a new state broadcast channel.
             ///
             /// Refer to [`generic_state_broadcast_channel`] for details.
+            ///
+            /// Example for creating a channel to transmit an integer value:
+            ///
+            /// ```
+            /// # use futures_intrusive::channel::shared::state_broadcast_channel;
+            /// let (sender, receiver) = state_broadcast_channel::<i32>();
+            /// ```
             pub fn state_broadcast_channel<T>(
             ) -> (StateSender<T>, StateReceiver<T>)
             where

--- a/src/sync/manual_reset_event.rs
+++ b/src/sync/manual_reset_event.rs
@@ -300,8 +300,8 @@ pub type LocalManualResetEvent = GenericManualResetEvent<NoopLock>;
 /// A [`GenericWaitForEventFuture`] for [`LocalManualResetEvent`].
 pub type LocalWaitForEventFuture<'a> = GenericWaitForEventFuture<'a, NoopLock>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
 
     // Export a thread-safe version using parking_lot::RawMutex
@@ -313,5 +313,5 @@ mod if_alloc {
         GenericWaitForEventFuture<'a, parking_lot::RawMutex>;
 }
 
-#[cfg(feature = "alloc")]
-pub use self::if_alloc::*;
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -10,7 +10,7 @@ pub use self::manual_reset_event::{
     LocalWaitForEventFuture,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::manual_reset_event::{ManualResetEvent, WaitForEventFuture};
 
 mod mutex;
@@ -20,7 +20,7 @@ pub use self::mutex::{
     LocalMutexGuard, LocalMutexLockFuture,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::mutex::{Mutex, MutexGuard, MutexLockFuture};
 
 mod semaphore;
@@ -33,7 +33,11 @@ pub use self::semaphore::{
 #[cfg(feature = "alloc")]
 pub use self::semaphore::{
     GenericSharedSemaphore, GenericSharedSemaphoreAcquireFuture,
-    GenericSharedSemaphoreReleaser, Semaphore, SemaphoreAcquireFuture,
-    SemaphoreReleaser, SharedSemaphore, SharedSemaphoreAcquireFuture,
-    SharedSemaphoreReleaser,
+    GenericSharedSemaphoreReleaser,
+};
+
+#[cfg(feature = "std")]
+pub use self::semaphore::{
+    Semaphore, SemaphoreAcquireFuture, SemaphoreReleaser, SharedSemaphore,
+    SharedSemaphoreAcquireFuture, SharedSemaphoreReleaser,
 };

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -478,8 +478,8 @@ pub type LocalMutexGuard<'a, T> = GenericMutexGuard<'a, NoopLock, T>;
 /// A [`GenericMutexLockFuture`] for [`LocalMutex`].
 pub type LocalMutexLockFuture<'a, T> = GenericMutexLockFuture<'a, NoopLock, T>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
 
     // Export a thread-safe version using parking_lot::RawMutex
@@ -494,5 +494,5 @@ mod if_alloc {
         GenericMutexLockFuture<'a, parking_lot::RawMutex, T>;
 }
 
-#[cfg(feature = "alloc")]
-pub use self::if_alloc::*;
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/src/sync/semaphore.rs
+++ b/src/sync/semaphore.rs
@@ -541,11 +541,9 @@ pub type LocalSemaphoreReleaser<'a> = GenericSemaphoreReleaser<'a, NoopLock>;
 pub type LocalSemaphoreAcquireFuture<'a> =
     GenericSemaphoreAcquireFuture<'a, NoopLock>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
-
-    use alloc::sync::Arc;
 
     // Export a thread-safe version using parking_lot::RawMutex
 
@@ -557,6 +555,16 @@ mod if_alloc {
     /// A [`GenericSemaphoreAcquireFuture`] for [`Semaphore`].
     pub type SemaphoreAcquireFuture<'a> =
         GenericSemaphoreAcquireFuture<'a, parking_lot::RawMutex>;
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use super::*;
+
+    use alloc::sync::Arc;
 
     /// An RAII guard returned by the `acquire` and `try_acquire` methods.
     ///
@@ -814,14 +822,24 @@ mod if_alloc {
         }
     }
 
-    /// A [`GenericSharedSemaphore`] backed by [`parking_lot`].
-    pub type SharedSemaphore = GenericSharedSemaphore<parking_lot::RawMutex>;
-    /// A [`GenericSharedSemaphoreReleaser`] for [`SharedSemaphore`].
-    pub type SharedSemaphoreReleaser =
-        GenericSharedSemaphoreReleaser<parking_lot::RawMutex>;
-    /// A [`GenericSharedSemaphoreAcquireFuture`] for [`SharedSemaphore`].
-    pub type SharedSemaphoreAcquireFuture =
-        GenericSharedSemaphoreAcquireFuture<parking_lot::RawMutex>;
+    // Export parking_lot based shared semaphores in std mode
+    #[cfg(feature = "std")]
+    mod if_std {
+        use super::*;
+
+        /// A [`GenericSharedSemaphore`] backed by [`parking_lot`].
+        pub type SharedSemaphore =
+            GenericSharedSemaphore<parking_lot::RawMutex>;
+        /// A [`GenericSharedSemaphoreReleaser`] for [`SharedSemaphore`].
+        pub type SharedSemaphoreReleaser =
+            GenericSharedSemaphoreReleaser<parking_lot::RawMutex>;
+        /// A [`GenericSharedSemaphoreAcquireFuture`] for [`SharedSemaphore`].
+        pub type SharedSemaphoreAcquireFuture =
+            GenericSharedSemaphoreAcquireFuture<parking_lot::RawMutex>;
+    }
+
+    #[cfg(feature = "std")]
+    pub use self::if_std::*;
 }
 
 #[cfg(feature = "alloc")]

--- a/src/timer/clock.rs
+++ b/src/timer/clock.rs
@@ -19,12 +19,12 @@ pub trait Clock: Sync {
 /// It can be used in a test case as demonstrated in the following example:
 /// ```
 /// use futures_intrusive::timer::MockClock;
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// # use futures_intrusive::timer::TimerService;
 ///
 /// static TEST_CLOCK: MockClock = MockClock::new();
 /// TEST_CLOCK.set_time(2300); // Set the current time
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// let timer = TimerService::new(&TEST_CLOCK);
 /// ```
 pub struct MockClock {

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -18,5 +18,5 @@ pub use self::timer::{
     Timer, TimerFuture,
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub use self::timer::TimerService;

--- a/src/timer/timer.rs
+++ b/src/timer/timer.rs
@@ -446,8 +446,8 @@ impl<'a> FusedFuture for TimerFuture<'a> {
 /// A [`GenericTimerService`] implementation which is not thread-safe.
 pub type LocalTimerService = GenericTimerService<NoopLock>;
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
 
     // Export a thread-safe version using parking_lot::RawMutex
@@ -456,5 +456,5 @@ mod if_alloc {
     pub type TimerService = GenericTimerService<parking_lot::RawMutex>;
 }
 
-#[cfg(feature = "alloc")]
-pub use self::if_alloc::*;
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/tests/mpmc_channel.rs
+++ b/tests/mpmc_channel.rs
@@ -1064,8 +1064,8 @@ gen_mpmc_tests!(
     LocalUnbufferedChannel
 );
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
     use futures_intrusive::channel::{
         shared::channel, shared::ChannelReceiveFuture,

--- a/tests/oneshot_channel.rs
+++ b/tests/oneshot_channel.rs
@@ -254,8 +254,8 @@ macro_rules! gen_oneshot_tests {
 
 gen_oneshot_tests!(local_oneshot_channel_tests, LocalOneshotChannel);
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
     use futures_intrusive::channel::shared::oneshot_channel;
     use futures_intrusive::channel::OneshotChannel;

--- a/tests/semaphore.rs
+++ b/tests/semaphore.rs
@@ -565,8 +565,8 @@ macro_rules! gen_semaphore_tests {
 
 gen_semaphore_tests!(local_semaphore_tests, LocalSemaphore);
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
     use futures::FutureExt;
     use futures_intrusive::sync::{Semaphore, SharedSemaphore};

--- a/tests/state_broadcast_channel.rs
+++ b/tests/state_broadcast_channel.rs
@@ -355,8 +355,8 @@ gen_state_broadcast_tests!(
     LocalStateBroadcastChannel
 );
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
     use futures_intrusive::channel::{
         shared::state_broadcast_channel, StateBroadcastChannel,

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -232,8 +232,8 @@ macro_rules! gen_timer_tests {
 
 gen_timer_tests!(local_timer_service_tests, LocalTimerService, LocalTimer);
 
-#[cfg(feature = "alloc")]
-mod if_alloc {
+#[cfg(feature = "std")]
+mod if_std {
     use super::*;
     use futures_intrusive::timer::{Timer, TimerService};
 


### PR DESCRIPTION
Currently you cannot build `alloc` version of the crate in `no_std` environment because `alloc` feature imports `parking_lot`. This PR decouples predefined `parking_lot` types and allows generic types to be used in `no_std` environment (with your own `RawMutex` implementation).