### PR TITLE
Add a Sync bound for GenericMutexGuard.. Fixes #53.

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -310,6 +310,13 @@ impl<MutexType: RawMutex, T> DerefMut for GenericMutexGuard<'_, MutexType, T> {
     }
 }
 
+// Safety: GenericMutexGuard may only be used across threads if the underlying
+// type is Sync.
+unsafe impl<MutexType: RawMutex, T: Sync> Sync
+    for GenericMutexGuard<'_, MutexType, T>
+{
+}
+
 /// A future which resolves when the target mutex has been successfully acquired.
 #[must_use = "futures do nothing unless polled"]
 pub struct GenericMutexLockFuture<'a, MutexType: RawMutex, T: 'a> {


### PR DESCRIPTION
I thought of fixing this by tossing in a `PhantomData` so that it would be valid when `T` is `Sync` but I don't think that's good since the `UnsafeCell` would still be accessed across threads. I thus ended up setting the trait `!Sync` like the nomicon suggests: https://doc.rust-lang.org/beta/nomicon/send-and-sync.html

I don't think this needs a test though theoretically this is possible, see https://users.rust-lang.org/t/a-macro-to-assert-that-a-type-does-not-implement-trait-bounds/31179.