### PR TITLE
implement Sync for SharedStream

### DIFF
--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -1070,6 +1070,16 @@ mod if_alloc {
             }
         }
 
+        // The stream is thread-safe as long as a thread-safe mutex is used
+        // and the inner future cannot be accessed by a shared reference.
+        unsafe impl<MutexType: RawMutex + Sync, T: Send, A> Sync
+            for SharedStream<MutexType, T, A>
+        where
+            A: RingBuf<Item = T>,
+        {
+        }
+
+
         // Export parking_lot based shared channels in std mode
         #[cfg(feature = "std")]
         mod if_std {

--- a/tests/mpmc_channel.rs
+++ b/tests/mpmc_channel.rs
@@ -1135,6 +1135,13 @@ mod if_std {
         is_send(&send_fut);
     }
 
+    #[test]
+    fn shared_channel_stream_is_sync() {
+        let (_, receiver) = channel::<i32>(1);
+        let stream = receiver.into_stream();
+        is_sync(&stream);
+    }
+
     // Check if SharedChannel can be used in traits
     pub trait StreamTrait {
         type Output;


### PR DESCRIPTION
Basically I'm wondering whether `SharedStream` could `unsafe impl Sync` but I'm not sure this is sound.

The trait sync is defined as
> The precise definition is: a type T is Sync if and only if &T is Send. In other words, if there is no possibility of undefined behavior (including data races) when passing &T references between threads.
> https://doc.rust-lang.org/std/marker/trait.Sync.html

So in other words, T is sync if a `Arc<T>` shared across threads couldn't possibly trigger UB.

Since no operation that takes a `&SharedStream` affects the contained `ChannelReceiveFuture`, this should be safe.