### PR TITLE
Fix LinkedList unsoundness

### DIFF
--- a/src/intrusive_double_linked_list.rs
+++ b/src/intrusive_double_linked_list.rs
@@ -81,12 +81,29 @@ impl<T> LinkedList<T> {
         }
     }
 
-    /// Returns the first node in the linked list without removing it from the list
+    /// Returns a reference to the first node in the linked list
     /// The function is only safe as long as valid pointers are stored inside
     /// the linked list.
     /// The returned pointer is only guaranteed to be valid as long as the list
     /// is not mutated
-    pub fn peek_first(&self) -> Option<&mut ListNode<T>> {
+    pub fn peek_first(&self) -> Option<&ListNode<T>> {
+        // Safety: When the node was inserted it was promised that it is alive
+        // until it gets removed from the list.
+        // The returned node has a pointer which constrains it to the lifetime
+        // of the list. This is ok, since the Node is supposed to outlive
+        // its insertion in the list.
+        unsafe {
+            self.head
+                .map(|node| &*(node.as_ptr() as *const ListNode<T>))
+        }
+    }
+
+    /// Returns a mutable reference to the first node in the linked list
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the linked list.
+    /// The returned pointer is only guaranteed to be valid as long as the list
+    /// is not mutated
+    pub fn peek_first_mut(&mut self) -> Option<&mut ListNode<T>> {
         // Safety: When the node was inserted it was promised that it is alive
         // until it gets removed from the list.
         // The returned node has a pointer which constrains it to the lifetime
@@ -98,12 +115,29 @@ impl<T> LinkedList<T> {
         }
     }
 
-    /// Returns the last node in the linked list without removing it from the list
+    /// Returns a reference to the last node in the linked list
     /// The function is only safe as long as valid pointers are stored inside
     /// the linked list.
     /// The returned pointer is only guaranteed to be valid as long as the list
     /// is not mutated
-    pub fn peek_last(&self) -> Option<&mut ListNode<T>> {
+    pub fn peek_last(&self) -> Option<&ListNode<T>> {
+        // Safety: When the node was inserted it was promised that it is alive
+        // until it gets removed from the list.
+        // The returned node has a pointer which constrains it to the lifetime
+        // of the list. This is ok, since the Node is supposed to outlive
+        // its insertion in the list.
+        unsafe {
+            self.tail
+                .map(|node| &*(node.as_ptr() as *const ListNode<T>))
+        }
+    }
+
+    /// Returns a mutable reference to the last node in the linked list
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the linked list.
+    /// The returned pointer is only guaranteed to be valid as long as the list
+    /// is not mutated
+    pub fn peek_last_mut(&mut self) -> Option<&mut ListNode<T>> {
         // Safety: When the node was inserted it was promised that it is alive
         // until it gets removed from the list.
         // The returned node has a pointer which constrains it to the lifetime

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -72,7 +72,7 @@ impl MutexState {
     /// the wait queue
     fn return_last_waiter(&mut self) -> Option<Waker> {
         let last_waiter = if self.is_fair {
-            self.waiters.peek_last()
+            self.waiters.peek_last_mut()
         } else {
             self.waiters.remove_last()
         };

--- a/src/sync/semaphore.rs
+++ b/src/sync/semaphore.rs
@@ -71,7 +71,7 @@ impl SemaphoreState {
         let mut available = self.permits;
 
         loop {
-            match self.waiters.peek_last() {
+            match self.waiters.peek_last_mut() {
                 None => return,
                 Some(last_waiter) => {
                     // Check if enough permits are available for this waiter.


### PR DESCRIPTION
I noticed a soundness issue while looking through the `LinkedList` implementation. Since `peek_first` and `peek_last` took a shared reference but returned a mutable reference to the `ListNode` it would be trivial to create multiple mutable references to the same `ListNode` which is UB, even from safe code:

```rust
        let mut a = ListNode::new(5);
        let mut list = LinkedList::new();

        unsafe {
            list.add_front(&mut a);
        }

        let a1 = list.peek_first().unwrap();
        let a2 = list.peek_first().unwrap();
        assert_eq!(a1 as *mut _, a2 as *mut _); // Undefined behavior
```

The good news is that the actual uses of `LinkedList` in the crate do not trigger that UB.

This PR fixes the problem by making `peek_first` and `peek_last` return shared references and adding `peek_first_mut` and `peek_last_mut` which take mutable references and return mutable references.