### PR TITLE
Refactor `ManualResetEvent` to use `PinList`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,15 @@ name = "futures_intrusive"
 
 [features]
 alloc = ["futures-core/alloc"]
-std = ["alloc", "parking_lot"]
+std = ["alloc", "parking_lot", "pin-list/std"]
 default = ["std"]
 
 [dependencies]
 futures-core = { version = "^0.3", default-features = false }
 lock_api = "0.4.1"
 parking_lot = { version = "0.12.0", optional = true }
+pin-list = "0.1.0"
+pin-project-lite = "0.2.9"
 
 [dev-dependencies]
 futures = { version = "0.3.0", default-features = true, features=["async-await"] }

--- a/src/channel/mpmc.rs
+++ b/src/channel/mpmc.rs
@@ -3,7 +3,7 @@
 use crate::intrusive_double_linked_list::{LinkedList, ListNode};
 use crate::{
     buffer::{ArrayBuf, RingBuf},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::{marker::PhantomData, pin::Pin};
@@ -182,7 +182,7 @@ where
                 // to unregistered there can't be space available in the channel.
                 // However the caller might have passed a different `Waker`.
                 // In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
+                update_option_waker_ref(&mut wait_node.task, cx);
                 (Poll::Pending, None, None)
             }
             SendPollState::SendComplete => {
@@ -289,7 +289,7 @@ where
                 // to unregistered there can't be any value in the channel in
                 // this state. However the caller might have passed a different `Waker`.
                 // In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
+                update_option_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
         }

--- a/src/channel/oneshot.rs
+++ b/src/channel/oneshot.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     intrusive_double_linked_list::{LinkedList, ListNode},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::marker::PhantomData;
@@ -111,7 +111,7 @@ impl<T> ChannelState<T> {
                 // to unregistered there can't be any value in the channel in this state.
                 // However the caller might have passed a different `Waker`.
                 // In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
+                update_option_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
             RecvPollState::Notified => {

--- a/src/channel/oneshot_broadcast.rs
+++ b/src/channel/oneshot_broadcast.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     intrusive_double_linked_list::{LinkedList, ListNode},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::marker::PhantomData;
@@ -116,7 +116,7 @@ where
                 // to unregistered there can't be any value in the channel in this state.
                 // However the caller might have passed a different `Waker`.
                 // In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
+                update_option_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
             RecvPollState::Notified => {

--- a/src/channel/state_broadcast.rs
+++ b/src/channel/state_broadcast.rs
@@ -3,7 +3,7 @@
 use super::{ChannelSendError, CloseStatus};
 use crate::{
     intrusive_double_linked_list::{LinkedList, ListNode},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::marker::PhantomData;
@@ -288,7 +288,7 @@ where
                 // to unregistered there can't be any value in the channel in this state.
                 // However the caller might have passed a different `Waker`.
                 // In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
+                update_option_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
         }

--- a/src/sync/manual_reset_event.rs
+++ b/src/sync/manual_reset_event.rs
@@ -1,58 +1,34 @@
 //! An asynchronously awaitable event for signalization between tasks
 
-use crate::{
-    intrusive_double_linked_list::{LinkedList, ListNode},
-    utils::update_waker_ref,
-    NoopLock,
-};
+use crate::{utils::update_waker_ref, NoopLock};
 use core::pin::Pin;
 use futures_core::{
     future::{FusedFuture, Future},
     task::{Context, Poll, Waker},
 };
 use lock_api::{Mutex, RawMutex};
+use pin_list::PinList;
+use pin_project_lite::pin_project;
 
-/// Tracks how the future had interacted with the event
-#[derive(PartialEq)]
-enum PollState {
-    /// The task has never interacted with the event.
-    New,
-    /// The task was added to the wait queue at the event.
-    Waiting,
-    /// The task has been polled to completion.
-    Done,
-}
-
-/// Tracks the WaitForEventFuture waiting state.
-/// Access to this struct is synchronized through the mutex in the Event.
-struct WaitQueueEntry {
-    /// The task handle of the waiting task
-    task: Option<Waker>,
-    /// Current polling state
-    state: PollState,
-}
-
-impl WaitQueueEntry {
-    /// Creates a new WaitQueueEntry
-    fn new() -> WaitQueueEntry {
-        WaitQueueEntry {
-            task: None,
-            state: PollState::New,
-        }
-    }
-}
+type PinListTypes = dyn pin_list::Types<
+    Id = pin_list::id::Checked,
+    // The waker that will wake this task in the list.
+    Protected = Waker,
+    Removed = (),
+    Unprotected = (),
+>;
 
 /// Internal state of the `ManualResetEvent` pair above
 struct EventState {
     is_set: bool,
-    waiters: LinkedList<WaitQueueEntry>,
+    waiters: PinList<PinListTypes>,
 }
 
 impl EventState {
     fn new(is_set: bool) -> EventState {
         EventState {
             is_set,
-            waiters: LinkedList::new(),
+            waiters: PinList::new(pin_list::id::Checked::new()),
         }
     }
 
@@ -72,14 +48,8 @@ impl EventState {
             // only move it from the blocked into the ready state and not have
             // further side effects.
 
-            // Use a reverse iterator, so that the oldest waiter gets
-            // scheduled first
-            self.waiters.reverse_drain(|waiter| {
-                if let Some(handle) = waiter.task.take() {
-                    handle.wake();
-                }
-                waiter.state = PollState::Done;
-            });
+            let mut cursor = self.waiters.cursor_front_mut();
+            while cursor.remove_current_with_or(|waker| waker.wake(), || {}) {}
         }
     }
 
@@ -90,56 +60,53 @@ impl EventState {
     /// Checks if the event is set. If it is this returns immediately.
     /// If the event isn't set, the WaitForEventFuture gets added to the wait
     /// queue at the event, and will be signalled once ready.
-    /// This function is only safe as long as the `wait_node`s address is guaranteed
-    /// to be stable until it gets removed from the queue.
-    unsafe fn try_wait(
+    fn try_wait(
         &mut self,
-        wait_node: &mut ListNode<WaitQueueEntry>,
+        mut wait_node: Pin<&mut pin_list::Node<PinListTypes>>,
         cx: &mut Context<'_>,
     ) -> Poll<()> {
-        match wait_node.state {
-            PollState::New => {
+        match wait_node.as_mut().initialized_mut() {
+            // We haven't started waiting yet
+            None => {
                 if self.is_set {
                     // The event is already signaled
-                    wait_node.state = PollState::Done;
                     Poll::Ready(())
                 } else {
                     // Added the task to the wait queue
-                    wait_node.task = Some(cx.waker().clone());
-                    wait_node.state = PollState::Waiting;
-                    self.waiters.add_front(wait_node);
+                    self.waiters.push_back(wait_node, cx.waker().clone(), ());
                     Poll::Pending
                 }
             }
-            PollState::Waiting => {
-                // The WaitForEventFuture is already in the queue.
-                // The event can't have been set, since this would change the
-                // waitstate inside the mutex. However the caller might have
-                // passed a different `Waker`. In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
-                Poll::Pending
-            }
-            PollState::Done => {
-                // We have been woken up by the event.
-                // This does not guarantee that the event is still set. It could
-                // have been reset it in the meantime.
-                Poll::Ready(())
+            // We are in the middle of waiting, or we have been woken
+            Some(node) => {
+                match node.take_removed(&self.waiters) {
+                    // The WaitForEventFuture is still in the queue.
+                    // The event can't have been set, since this would change the
+                    // waitstate inside the mutex. However the caller might have
+                    // passed a different `Waker`. In this case we need to update it.
+                    Err(node) => {
+                        let waker =
+                            node.protected_mut(&mut self.waiters).unwrap();
+                        update_waker_ref(waker, cx);
+                        Poll::Pending
+                    }
+                    // We have been woken up by the event.
+                    // This does not guarantee that the event is still set. It could
+                    // have been reset it in the meantime.
+                    Ok(((), ())) => Poll::Ready(()),
+                }
             }
         }
     }
 
-    fn remove_waiter(&mut self, wait_node: &mut ListNode<WaitQueueEntry>) {
+    fn remove_waiter(
+        &mut self,
+        wait_node: Pin<&mut pin_list::Node<PinListTypes>>,
+    ) {
         // WaitForEventFuture only needs to get removed if it has been added to
-        // the wait queue of the Event. This has happened in the PollState::Waiting case.
-        if let PollState::Waiting = wait_node.state {
-            // Safety: Due to the state, we know that the node must be part
-            // of the waiter list
-            if !unsafe { self.waiters.remove(wait_node) } {
-                // Panic if the address isn't found. This can only happen if the contract was
-                // violated, e.g. the WaitQueueEntry got moved after the initial poll.
-                panic!("Future could not be removed from wait queue");
-            }
-            wait_node.state = PollState::Done;
+        // the wait queue of the Event.
+        if let Some(node) = wait_node.initialized_mut() {
+            let _ = node.reset(&mut self.waiters);
         }
     }
 }
@@ -150,17 +117,6 @@ impl EventState {
 /// This Future will get fulfilled when the event has been set.
 pub struct GenericManualResetEvent<MutexType: RawMutex> {
     inner: Mutex<MutexType, EventState>,
-}
-
-// The Event is can be sent to other threads as long as it's not borrowed
-unsafe impl<MutexType: RawMutex + Send> Send
-    for GenericManualResetEvent<MutexType>
-{
-}
-// The Event is thread-safe as long as the utilized Mutex is thread-safe
-unsafe impl<MutexType: RawMutex + Sync> Sync
-    for GenericManualResetEvent<MutexType>
-{
 }
 
 impl<MutexType: RawMutex> core::fmt::Debug
@@ -200,38 +156,46 @@ impl<MutexType: RawMutex> GenericManualResetEvent<MutexType> {
     pub fn wait(&self) -> GenericWaitForEventFuture<MutexType> {
         GenericWaitForEventFuture {
             event: Some(self),
-            wait_node: ListNode::new(WaitQueueEntry::new()),
+            wait_node: pin_list::Node::new(),
         }
     }
 
-    unsafe fn try_wait(
+    fn try_wait(
         &self,
-        wait_node: &mut ListNode<WaitQueueEntry>,
+        wait_node: Pin<&mut pin_list::Node<PinListTypes>>,
         cx: &mut Context<'_>,
     ) -> Poll<()> {
         self.inner.lock().try_wait(wait_node, cx)
     }
 
-    fn remove_waiter(&self, wait_node: &mut ListNode<WaitQueueEntry>) {
+    fn remove_waiter(&self, wait_node: Pin<&mut pin_list::Node<PinListTypes>>) {
         self.inner.lock().remove_waiter(wait_node)
     }
 }
 
-/// A Future that is resolved once the corresponding ManualResetEvent has been set
-#[must_use = "futures do nothing unless polled"]
-pub struct GenericWaitForEventFuture<'a, MutexType: RawMutex> {
-    /// The ManualResetEvent that is associated with this WaitForEventFuture
-    event: Option<&'a GenericManualResetEvent<MutexType>>,
-    /// Node for waiting at the event
-    wait_node: ListNode<WaitQueueEntry>,
-}
+pin_project! {
+    /// A Future that is resolved once the corresponding ManualResetEvent has been set
+    #[must_use = "futures do nothing unless polled"]
+    pub struct GenericWaitForEventFuture<'a, MutexType: RawMutex> {
+        // The ManualResetEvent that is associated with this WaitForEventFuture
+        event: Option<&'a GenericManualResetEvent<MutexType>>,
+        // Node for waiting at the event
+        #[pin]
+        wait_node: pin_list::Node<PinListTypes>,
+    }
 
-// Safety: Futures can be sent between threads as long as the underlying
-// event is thread-safe (Sync), which allows to poll/register/unregister from
-// a different thread.
-unsafe impl<'a, MutexType: RawMutex + Sync> Send
-    for GenericWaitForEventFuture<'a, MutexType>
-{
+    impl<MutexType: RawMutex> PinnedDrop for GenericWaitForEventFuture<'_, MutexType> {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+
+            // If this WaitForEventFuture has been polled and it was added to the
+            // wait queue at the event, it must be removed before dropping.
+            // Otherwise the event would access invalid memory.
+            if let Some(ev) = this.event {
+                ev.remove_waiter(this.wait_node);
+            }
+        }
+    }
 }
 
 impl<'a, MutexType: RawMutex> core::fmt::Debug
@@ -248,24 +212,17 @@ impl<'a, MutexType: RawMutex> Future
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        // It might be possible to use Pin::map_unchecked here instead of the two unsafe APIs.
-        // However this didn't seem to work for some borrow checker reasons
+        let this = self.project();
 
-        // Safety: The next operations are safe, because Pin promises us that
-        // the address of the wait queue entry inside MutexLocalFuture is stable,
-        // and we don't move any fields inside the future until it gets dropped.
-        let mut_self: &mut GenericWaitForEventFuture<MutexType> =
-            unsafe { Pin::get_unchecked_mut(self) };
-
-        let event = mut_self
+        let event = this
             .event
             .expect("polled WaitForEventFuture after completion");
 
-        let poll_res = unsafe { event.try_wait(&mut mut_self.wait_node, cx) };
+        let poll_res = event.try_wait(this.wait_node, cx);
 
         if let Poll::Ready(()) = poll_res {
             // The event was set
-            mut_self.event = None;
+            *this.event = None;
         }
 
         poll_res
@@ -277,19 +234,6 @@ impl<'a, MutexType: RawMutex> FusedFuture
 {
     fn is_terminated(&self) -> bool {
         self.event.is_none()
-    }
-}
-
-impl<'a, MutexType: RawMutex> Drop
-    for GenericWaitForEventFuture<'a, MutexType>
-{
-    fn drop(&mut self) {
-        // If this WaitForEventFuture has been polled and it was added to the
-        // wait queue at the event, it must be removed before dropping.
-        // Otherwise the event would access invalid memory.
-        if let Some(ev) = self.event {
-            ev.remove_waiter(&mut self.wait_node);
-        }
     }
 }
 

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     intrusive_double_linked_list::{LinkedList, ListNode},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::{
@@ -160,7 +160,7 @@ impl MutexState {
                     // The task needs to wait until it gets notified in order to
                     // maintain the ordering. However the caller might have
                     // passed a different `Waker`. In this case we need to update it.
-                    update_waker_ref(&mut wait_node.task, cx);
+                    update_option_waker_ref(&mut wait_node.task, cx);
                     Poll::Pending
                 } else {
                     // For throughput improvement purposes, grab the lock immediately
@@ -177,7 +177,7 @@ impl MutexState {
                     } else {
                         // The caller might have passed a different `Waker`.
                         // In this case we need to update it.
-                        update_waker_ref(&mut wait_node.task, cx);
+                        update_option_waker_ref(&mut wait_node.task, cx);
                         Poll::Pending
                     }
                 }

--- a/src/sync/semaphore.rs
+++ b/src/sync/semaphore.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     intrusive_double_linked_list::{LinkedList, ListNode},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::pin::Pin;
@@ -179,7 +179,7 @@ impl SemaphoreState {
                     // maintain the ordering.
                     // However the caller might have passed a different `Waker`.
                     // In this case we need to update it.
-                    update_waker_ref(&mut wait_node.task, cx);
+                    update_option_waker_ref(&mut wait_node.task, cx);
                     Poll::Pending
                 } else {
                     // For throughput improvement purposes, check immediately
@@ -196,7 +196,7 @@ impl SemaphoreState {
                     } else {
                         // The caller might have passed a different `Waker`.
                         // In this case we need to update it.
-                        update_waker_ref(&mut wait_node.task, cx);
+                        update_option_waker_ref(&mut wait_node.task, cx);
                         Poll::Pending
                     }
                 }

--- a/src/timer/timer.rs
+++ b/src/timer/timer.rs
@@ -3,7 +3,7 @@
 use super::clock::Clock;
 use crate::{
     intrusive_pairing_heap::{HeapNode, PairingHeap},
-    utils::update_waker_ref,
+    utils::update_option_waker_ref,
     NoopLock,
 };
 use core::{pin::Pin, time::Duration};
@@ -117,7 +117,7 @@ impl TimerState {
                 // Expired when the timer expired, it can't be expired here yet.
                 // However the caller might have passed a different `Waker`.
                 // In this case we need to update it.
-                update_waker_ref(&mut wait_node.task, cx);
+                update_option_waker_ref(&mut wait_node.task, cx);
                 Poll::Pending
             }
             PollState::Expired => Poll::Ready(()),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,11 +4,17 @@ use core::task::{Context, Waker};
 
 /// Updates a `Waker` which is stored inside a `Option` to the newest value
 /// which is delivered via a `Context`.
-pub fn update_waker_ref(waker_option: &mut Option<Waker>, cx: &Context) {
+pub fn update_option_waker_ref(waker_option: &mut Option<Waker>, cx: &Context) {
     if waker_option
         .as_ref()
         .map_or(true, |stored_waker| !stored_waker.will_wake(cx.waker()))
     {
         *waker_option = Some(cx.waker().clone());
+    }
+}
+
+pub fn update_waker_ref(waker: &mut Waker, cx: &Context<'_>) {
+    if !waker.will_wake(cx.waker()) {
+        *waker = cx.waker().clone();
     }
 }


### PR DESCRIPTION
By using my [`PinList`] abstraction instead of the `LinkedList` abstraction, `ManualResetEvent` can be implemented in fully safe code. This is quite a benefit because it also makes it clear that it’s not UB (#56) — the fundamental problem is still there but because it’s abstracted in the [`PinList`] by [`pinned-aliasable`](https://docs.rs/pinned-aliasable) I think it’s a lot more acceptable to have (and it also works under Miri).

If there is interest, I would be happy to refactor more of the types provided by this crate to use [`PinList`] — so far it’s just a proof-of-concept for the simplest one.

[`PinList`]: https://docs.rs/pin-list/latest/pin_list/struct.PinList.html